### PR TITLE
feat(skills): absorb dsh-session-recovery into harness-ops toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # dsh-harness-ops — DeepSeek Harness 运维工具箱（自愈 + 版本轮换）
 
 > **这个仓库是 DSH 的"运维自愈工具箱"**：让 harness 在崩溃、升级、切换时都能自动恢复、
-> 无需人工干预。三个组件各管一段：
+> 无需人工干预。四个组件各管一段：
 >
 > | 组件 | 类型 | 管什么 |
 > |---|---|---|
 > | **`skills/dsh-snapshot-ab`** | skill | 官方每日快照 A/B 双槽轮换 —— 升级"切对版本" |
 > | **`skills/dsh-web-guard`** | skill | 自愈守护 —— web 死后 10s 自动拉起 |
+> | **`skills/dsh-session-recovery`** | skill | 会话丢失诊断 —— “0 sessions”/日志损坏时的定位与无损修复 |
 > | **`plugins/dsh-restart-recover`** | cordis 插件 | 重启续接 —— 被中断的 turn 自动继续 |
 >
-> 合起来回答三个问题：**web 挂了谁拉起？拉起后工作继续吗？官方发新版本怎么安全切换？**
+> 合起来回答四个问题：**web 挂了谁拉起？拉起后工作继续吗？会话看起来丢了怎么办？官方发新版本怎么安全切换？**
 > 三者互补：`ab.sh switch/rollback` 杀 web → `dsh-web-guard` 拉起 → `dsh-restart-recover` 续接。
 >
 > > 曾用名 `dsh-skill-snapshot-ab`（2026-08-11 更名）—— 仓库从"纯 AB 轮换 skill"长成了
@@ -28,6 +29,8 @@ dsh-harness-ops（本仓库）
 │   └── scripts/ab.sh              主命令（status/discover/prepare/verify/switch/confirm/rollback）
 ├── skills/dsh-web-guard/          自愈守护：launchd/systemd 托管，端口空闲 10s 内拉起 web
 │   └── scripts/install.sh         跨平台安装（macOS launchd / Linux systemd）
+├── skills/dsh-session-recovery/  会话丢失诊断：0 sessions/日志损坏 → 定位 → 无损修复 → 重启
+│   └── scripts/                   validate-sessions / repair-session-log / check-all-sessions
 └── plugins/dsh-restart-recover/   重启续接插件：agent/created 检测 interrupted → 自动注入续接
     └── src/index.ts               cordis 插件（监听 agent/created，零 dsh-track 依赖）
 ```
@@ -63,6 +66,7 @@ dsh-harness-ops（本仓库）
 ```sh
 # 1) 把 skill 装进默认扫描目录
 mkdir -p ~/.dsh/skills && cp -r skills/dsh-snapshot-ab ~/.dsh/skills/
+cp -r skills/dsh-session-recovery ~/.dsh/skills/   # 会话恢复 skill（诊断/修复 session 日志损坏）
 
 # 2) 配置（首次会自动读，示例见 skills/dsh-snapshot-ab/references/ab-config.example.json）
 #    通常只需确认 ab-config.json 里的 extensions（扩展仓库路径）与 web 端口
@@ -278,7 +282,7 @@ lsof -tiTCP:<port> -sTCP:LISTEN | xargs kill
 ### 场景 J · 重启后会话"找不回来"
 
 - 会话不丢：`~/.dsh/sessions/` 按工作区存放，重启后重新索引。GUI 侧边栏应有全部历史。
-- 仍看不到？用 `dsh-session-recovery` skill（专门的诊断/修复流程）。
+- 仍看不到？用同仓库的 `skills/dsh-session-recovery` skill（专门的诊断/修复流程）。
 - 想从断点继续：新会话里说"继续 snapshot-ab"，agent 会加载本 skill 并读
   `HANDOFF-snapshot-ab.md` / `USER-GUIDE-snapshot-ab.md`。
 
@@ -350,6 +354,7 @@ ln -sfn ~/.dsh/source/current/bin/dsh ~/.local/bin/dsh
   用户零输入）。三者互补：`ab.sh switch/rollback` 杀 web → guard 拉起 → recover 续接。
   插件从 dsh-track 独立出来（2026-08-11），因为它和 guard 一样是**平台级自愈能力**，
   不该绑在业务插件 dsh-track 上。
+- **`dsh-session-recovery`（同仓库 skill，2026-08-11 并入）**：会话丢失的诊断/修复/重启流程，事故复盘见 `skills/dsh-session-recovery/references/incident-20260809-session-loss.md`。
 - 社区 `mainline-compat`（dsh-external-research）：插件 ↔ 当日 mainline 的**兼容性监控/报告**；
   它答"插件还能不能用"，本机制答"怎么安全地切过去"。
 - `dshx-update-check`：commit SHA 对比**检测**更新（只检测）。

--- a/skills/dsh-session-recovery/SKILL.md
+++ b/skills/dsh-session-recovery/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: dsh-session-recovery
+description: 诊断并修复 DeepSeek Harness 会话丢失/消失事故：GUI 侧边栏显示 "0 sessions"、会话列表为空、session 全部不见了、或出现 "corrupt Zstandard session log" / "first frame is not exactly one header line" / "torn JSONL record" 等校验错误。覆盖损坏 session 日志（session.jsonl.zstd）的定位与无损修复、备份与回滚、重启 dsh web 前写 handoff、修复后验证。当用户提到会话丢失、session 消失、0 sessions、日志损坏、重启后会话没了、或 session 相关校验报错时，务必使用本 skill，即使问题看起来像是"系统崩溃"或"integration 校验挂了"。
+license: BSD-3-Clause
+metadata:
+  version: 1.0.0
+  author: fakechris
+---
+
+# DSH Session Recovery — 会话丢失事故的定位与无损修复
+
+本 skill 来自一次真实事故（见 `references/incident-20260809-session-loss.md`）：
+某个 session 日志被外部工具重压成单帧，导致 DSH 强校验在 `list()` 阶段整体抛错，
+**全部**会话在 GUI 里消失（磁盘文件其实都在）。
+
+## 核心心智模型（先理解再动手）
+
+1. **DSH 的 session 日志是强校验的 append-only 格式**（`session-persistence-jsonl`）：
+   - 文件 = 多个独立 zstd frame 拼接；
+   - **第 1 个 frame 必须恰好只含 header 那一行**（`assertZstdHeaderFrame`）；
+   - 后续每个 frame 必须在记录边界结束（换行符结尾），否则报 torn JSONL record；
+   - 每个 frame 带 XXH64 content checksum。
+2. **`persistence.list()` 一个文件校验失败就整体 throw** —— 一个坏文件能让所有会话从 GUI 消失。
+3. **workspace 注册表只在服务启动时构建 session 索引**（`sessionPaths` map）：
+   修复文件后**必须重启 dsh web**，运行中的服务不会自动重扫磁盘。
+4. **重启可能杀死当前 agent 运行时**（agent 会话由 web 服务托管）——重启前必须写 handoff。
+
+## 触发场景
+
+- 用户说：会话不见了 / 全部没了 / 0 sessions / sessions 消失 / 重启后会话没了。
+- GUI 侧边栏 workspace 下显示 "0 sessions"，但磁盘上 session 文件还在。
+- 任何 `corrupt Zstandard session log` / `first frame is not exactly one header line` /
+  `torn JSONL record` / `seq gap in committed region` / `invalid frame magic` 错误。
+
+## 诊断流程
+
+所有脚本都在本 skill 的 `scripts/` 下，用 DSH **编译产物**（与运行中服务同款代码）校验。
+
+### 1. 确认磁盘状态（数据是否还在）
+
+```sh
+ls ~/.dsh/sessions/                          # 会话根目录（每个项目一个 --path-- 目录）
+cat ~/.dsh/storages/workspace.json           # workspace 登记了哪些 sessionId（别改它）
+ls ~/.dsh/sessions/--<project>--/<session-id>/
+```
+
+文件还在 + workspace.json 还登记 → 是"索引/校验"问题，不是数据丢失。别慌，可无损修复。
+
+### 2. 逐文件定位坏日志
+
+```sh
+node scripts/validate-sessions.mjs            # 逐文件校验首个 frame 是否为单行 header
+```
+
+- 输出 `FAIL — corrupt Zstandard session log: first frame is not exactly one header line`
+  → 该文件帧结构坏了（典型：被 `zstd` CLI 整文件重压成单帧）。
+- 输出 `header frame OK` 的文件没问题，**不要动它们**。
+
+### 3. 确认损坏形态（顺手做的证据）
+
+```sh
+zstd -lv <坏文件>      # 看 "Zstandard Frames: N" —— 正常应 >1（几十~上百），坏文件常为 1
+zstd -dc <坏文件> | wc -l   # 明文行数仍在 = 内容没丢，只是帧结构错
+```
+
+## 修复流程（内容零丢失）
+
+```sh
+node scripts/repair-session-log.mjs --id <session-id>
+# 或 --dir /Users/.../session-xxxx/session.jsonl.zstd
+```
+
+脚本自动完成（每一步失败都回滚）：
+1. 解压 → 校验 header（id/cwd 必须匹配）、所有行是合法 JSON；
+2. **备份**坏文件到工作目录 `backups/`；
+3. 用 DSH 同款压缩器（`node:zlib zstdCompress` + `ZSTD_c_checksumFlag=1`）逐行重排：
+   frame1 = 仅 header 行；其余按行对齐分帧（每帧以换行结尾）；
+4. 两步可逆交换（`rename 原文件 → .orig-in-place`，再 `rename 新文件 → 原位`）；
+5. 用 DSH 读取器在**规范路径**上做全量校验（`readPrefix`：无 torn record、seq 连续）
+   并通过 `decodeStorageRecord` 对原始明文逐事件比对（**注意：行数 ≠ 事件数**，
+   日志里 chunk 行是打包的，`readPrefix` 会解包，事件数可比行数多十几倍）；
+6. 全部通过才删除 `.orig-in-place`。
+
+⚠️ **绝不要**用系统 `zstd` CLI 重压 session 日志 —— 它默认整文件单帧，正好触发本事故。
+⚠️ **绝不要**手工编辑 session 日志或改动文件里的行。
+
+## 重启 + handoff（重中之重的纪律）
+
+修复后 workspace 索引仍为空，必须重启 `dsh web`。顺序：
+
+1. **先写 handoff**（哪怕只是临时文件）：
+   - 症状、根因、已做修复、备份位置、待办、验证方法、回滚方法；
+   - 明确写出"重启会杀死当前 agent 运行时"这一事实。
+2. 重启：
+   ```sh
+   sh scripts/restart-dsh-web.sh            # 默认杀旧 PID、nohup 重启、轮询 HTTP 200
+   ```
+   - 用 `nohup ... &` 启动，保证即使 agent 进程随旧服务一起死掉，新服务也能存活；
+   - 启动目录与原服务一致（`dsh web` 的 cwd 会影响默认 workspace）。
+3. 验证（重启后立刻）：
+   ```sh
+   curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3080/   # 期望 200
+   node scripts/check-all-sessions.mjs      # 22/22 全量读取通过
+   ```
+   并在 GUI 里确认 workspace 下 session 数量恢复、标题正确。
+
+## 排查同类问题的其他线索
+
+- `~/.dsh/storages/session_projcache.json` 存了标题/目标/todos——它没坏的话，恢复后标题都在。
+- 服务进程：`lsof -iTCP:3080 -sTCP:LISTEN`；启动方式看 `~/.zsh_history` 里的 `dsh web`。
+- DSH 配置：会话根目录在 `packages/bundle/base/cordis.patch.yml`（`root: dshHomePath('sessions')`）；
+  API key 等从 `~/.dsh/.env` 读取，新服务自动继承，无需担心环境变量。
+- 若 `list()` 抛的不是帧结构错误（如 `legacy flat-file layout` / `encoding mismatch`），
+  是文件放错目录/压缩模式冲突，先看 `session-persistence-jsonl` 的 `listArtifacts()` 逻辑再动手。
+
+## 预防
+
+- 需要改 session 日志时，走 DSH 自身写入路径（append/打包），或本 skill 的 repair 脚本。
+- 对 `~/.dsh/sessions` 的任何写操作：先备份 → 先校验 → 原子 rename + 可回滚两步交换。
+- 定期备份 `~/.dsh/sessions/`（本事故中"修复前的多帧版本"没有副本，只有坏掉的单帧版）。
+
+## 参考
+
+- `references/incident-20260809-session-loss.md` — 本次事故完整复盘（症状→定位→修复→重启→验证）。
+- `scripts/validate-sessions.mjs` — 逐文件 header 校验。
+- `scripts/check-all-sessions.mjs` — 全量读取校验。
+- `scripts/repair-session-log.mjs` — 无损修复（通用化，按 id 或目录）。
+- `scripts/restart-dsh-web.sh` — 重启 + 验证。

--- a/skills/dsh-session-recovery/references/incident-20260809-session-loss.md
+++ b/skills/dsh-session-recovery/references/incident-20260809-session-loss.md
@@ -1,0 +1,103 @@
+# 事故复盘：2026-08-09 会话集体消失（"0 sessions"）
+
+> 本文是 `dsh-session-recovery` skill 的出处。记录一次真实事故的完整过程：
+> 症状 → 定位 → 修复 → 重启 → 验证，以及所有踩过的坑。
+
+## 时间线
+
+| 时间 | 事件 |
+|---|---|
+| 12:04 | 某次"修复"把 `session-026b244d.../session.jsonl.zstd` 整体重压成 **单个 zstd frame**（1.7MB，15,622 行明文） |
+| 12:05 | `dsh web` 重启；启动时 `persistence.list()` 遇到该坏文件**整体 throw** → session 索引为空 |
+| 12:05 | GUI 侧边栏所有 workspace 显示 **"0 sessions"**（5 个 explorer 会话"全部消失"） |
+| 12:0x | 用户报告："修复半天的 session 全部不见了！怀疑系统有 integration 校验" |
+| 12:16 | 定位根因：唯一坏文件 = 首帧非单行 header → 重排修复 → 22/22 全量校验通过 |
+| 12:17 | 写 handoff → 重启服务 → GUI 恢复显示 6 sessions（5 个 + 当前会话） |
+
+## 症状
+
+- GUI 侧边栏：`Workspaces → explorer → 0 sessions`。
+- 磁盘上 5 个 session 文件全在，`~/.dsh/storages/workspace.json` 也登记了全部 5 个 sessionId。
+- 数据其实**没有任何丢失** —— 消失的只是"索引"。
+
+## 根因（机制）
+
+DSH 的 JSONL session 持久化（`packages/session/session-persistence-jsonl`）强校验：
+
+1. 文件 = 多个独立 zstd frame 拼接（每个 frame 带 XXH64 content checksum）。
+2. **第 1 个 frame 必须恰好只含 header 一行**（`assertZstdHeaderFrame`：
+   解压后唯一换行符必须是最后一个字节）。
+3. 后续每个 frame 必须在记录边界结束，否则报 torn JSONL record。
+4. 每条记录的 `seq` 必须连续，否则报 seq gap。
+
+`SessionPersistenceJsonl.list()` 遍历所有文件，**任何文件校验失败都直接 throw**，
+导致：
+- 服务启动时 session 索引构建失败 → workspace 的 `sessionIds` 投影全被过滤 → GUI 显示 0 sessions；
+- 其他 21 个文件全是好的，被一个坏文件连累。
+
+坏文件形态（`zstd -lv` 实测）：
+```
+# Zstandard Frames: 1        ← 正常应 ~80 帧
+Check: XXH64
+```
+即整个日志被 `zstd` CLI（或等价物）默认整文件单帧重压了。
+
+## 定位方法（当时实际用的）
+
+1. 确认文件都在、workspace.json 登记完好 → 判定为"索引/校验"问题。
+2. 用 DSH 编译产物直接调 `persistence.list()` → 复现 `corrupt Zstandard session log:
+   first frame is not exactly one header line`。
+3. 逐文件调 `readFirstZstdLine()` → 精确定位唯一坏文件（026b244d）。
+4. `zstd -lv` 确认单帧形态；`zstd -dc | wc -l` 确认明文完整（15,622 行）。
+
+## 修复方法（内容零丢失）
+
+1. 解压 → 校验 header（id/cwd 匹配）、全部行是合法 JSON。
+2. 备份坏文件。
+3. 用 DSH 同款压缩器重排帧：
+   - frame1 = 仅 header 行；
+   - 其余按 200 行/帧，每帧以换行结尾；
+   - 压缩参数 `node:zlib zstdCompress + { [ZSTD_c_checksumFlag]: 1 }`（与 DSH 写路径完全一致）。
+4. 两步可逆交换：`原文件 → .orig-in-place`，`新文件 → 原位`。
+5. 用 DSH 读取器在规范路径 `readPrefix()` 全量校验（无 torn record、seq 连续），
+   并对原始明文逐事件比对（`decodeStorageRecord` 解包）。
+   - ⚠️ **坑**：行数 ≠ 事件数。日志里 chunk 行是打包的，`readPrefix` 会解包——
+     15,621 行明文 = 235,257 个事件。第一次校验用"行数 == 事件数"判断，误报失败回滚了一次。
+6. 全部通过才删除 `.orig-in-place`。
+
+## 重启（为什么必须 + 怎么安全做）
+
+- **为什么必须**：workspace 注册表的 `sessionPaths` 索引只在启动时从 live sessions 构建，
+  运行中的服务不会自动重扫磁盘。文件修好后索引仍空 → 必须重启。
+- **为什么危险**：`dsh web` 托管了当前 agent 的会话（本会话日志由它写入）。
+  重启会杀死 agent 运行时。
+- **怎么安全做**：
+  1. 先写 handoff（症状/根因/修复/备份/待办/回滚/验证）；
+  2. 一个脚本内完成 kill → 等端口释放 → `nohup dsh web &`（新服务脱离 agent 存活）；
+  3. 轮询 HTTP 200 验证；
+  4. 用浏览器确认 GUI 侧边栏 session 数恢复。
+- 本机实际：`dsh web` 从 `/Users/chris/source/test-fakechris` 启动（shell 历史可查），
+  端口 3080 默认。`dsh` → `~/.local/bin/dsh` → `~/.dsh/source/current/bin/dsh`。
+
+## 验证结果
+
+- `persistence.list()` → 22 sessions（修复前 throw）。
+- `check-all-sessions.mjs` → 22/22 全量读取通过，0 失败。
+- GUI → explorer 6 sessions（5 个历史会话 + 当前会话），标题/目标来自
+  `session_projcache.json`（未损坏，无需恢复）。
+
+## 教训
+
+1. **绝不用系统 zstd CLI 重压 session 日志** —— 默认单帧，恰好触发本事故。
+2. `persistence.list()` 是"一个坏文件全盘 throw"的强校验 —— 排查消失问题时
+   先逐文件定位坏文件，不要急着改配置或删数据。
+3. 事件数 ≠ 行数（打包 chunk 行）—— 用 DSH 的解包逻辑比对，别用朴素行数。
+4. 写 `~/.dsh/sessions` 前先备份、先校验、用可回滚的两步交换。
+5. 重启前必写 handoff —— 服务器可能就是你所在的运行时。
+
+## 相关文件（本次事故产物，已并入 skill）
+
+- `scripts/validate-sessions.mjs` — 逐文件首帧校验。
+- `scripts/check-all-sessions.mjs` — 全量读取校验。
+- `scripts/repair-session-log.mjs` — 无损重排修复。
+- `scripts/restart-dsh-web.sh` — 安全重启 + 验证。

--- a/skills/dsh-session-recovery/scripts/check-all-sessions.mjs
+++ b/skills/dsh-session-recovery/scripts/check-all-sessions.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * check-all-sessions.mjs — full-read validation of every session log.
+ *
+ * Runs persistence.readPrefix() on every log: decodes ALL frames, validates
+ * header, torn-record boundaries, seq continuity — the same read the server
+ * performs when resuming sessions at startup. Use AFTER a repair to prove the
+ * whole store is healthy, and BEFORE restarting the server.
+ *
+ * Usage:
+ *   node check-all-sessions.mjs [--root <sessions-root>]
+ * Exit code 0 when all pass, 1 when any fail.
+ */
+import { parseArgs } from 'node:util'
+import { loadPersistence, enumerateSessionLogs } from './lib/dsh.mjs'
+
+const { values } = parseArgs({
+  options: {
+    root: { type: 'string' },
+  },
+})
+
+const { persistence } = loadPersistence(values.root)
+const logs = await enumerateSessionLogs(values.root)
+
+let pass = 0
+let fail = 0
+for (const entry of logs) {
+  try {
+    const prefix = await persistence.readPrefix(entry.log, entry.id)
+    const events = prefix.events
+    const last = events[events.length - 1]
+    console.log(`OK   ${entry.id}  events=${events.length}  lastSeq=${last ? last.seq : '-'}`)
+    pass++
+  } catch (error) {
+    console.error(`FAIL ${entry.id}: ${error.message}`)
+    console.error(`     ${entry.log}`)
+    fail++
+  }
+}
+console.log(`\nRESULT: ${pass} pass, ${fail} fail`)
+process.exit(fail > 0 ? 1 : 0)

--- a/skills/dsh-session-recovery/scripts/lib/dsh.mjs
+++ b/skills/dsh-session-recovery/scripts/lib/dsh.mjs
@@ -1,0 +1,113 @@
+/**
+ * Shared helpers: resolve the DSH session persistence backend and load it
+ * exactly as the running `dsh web` server uses it, across both install modes:
+ *
+ *  - source checkout (A/B snapshots): `$DSH_HOME/source/current` → packages/
+ *  - npm install (lib production):  `$DSH_HOME/profiles/node_modules` closure
+ */
+import { readlinkSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { createRequire } from 'node:module'
+
+export const DSH_HOME = process.env.DSH_HOME ?? join(homedir(), '.dsh')
+
+/** Locate the checkout: follow ~/.dsh/source/current, else newest staging-*. */
+export function resolveSourceRoot() {
+  const current = join(DSH_HOME, 'source', 'current')
+  try {
+    return readlinkSync(current)
+  } catch {
+    const sourceDir = join(DSH_HOME, 'source')
+    const candidates = readdirSync(sourceDir).filter(n => n.startsWith('staging-'))
+    if (candidates.length === 0) {
+      throw new Error(`cannot locate DSH source root: ${sourceDir} has no staging-* and current is missing`)
+    }
+    return join(sourceDir, candidates.sort().pop())
+  }
+}
+
+export const defaultSessionsRoot = () => join(DSH_HOME, 'sessions')
+
+/** 源码 checkout 是否存在（A/B 快照机制的特征）。 */
+function hasSourceCheckout() {
+  try {
+    const current = join(DSH_HOME, 'source', 'current')
+    readlinkSync(current)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 双路径解析 persistence 后端。判别以「是否有源码 checkout」为准：
+ * 源码模式（A/B 快照）→ 源码 packages/；npm 安装（lib 生产）→ profile 闭包。
+ */
+function persistenceRequire() {
+  if (hasSourceCheckout()) {
+    const sourceRoot = resolveSourceRoot()
+    const pkgDir = join(sourceRoot, 'packages', 'session', 'session-persistence-jsonl')
+    return { require: createRequire(join(pkgDir, 'package.json')), mode: 'source' }
+  }
+  const pkgDir = join(DSH_HOME, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-session-persistence-jsonl')
+  return { require: createRequire(join(pkgDir, 'package.json')), mode: 'npm' }
+}
+
+/**
+ * 双路径解析 `@deepseek-ai/dsh-session` 的 require（repair 脚本 decodeStorageRecord 用）。
+ * 判别与 persistenceRequire 一致：源码 checkout → 源码 packages/；npm → profile 闭包。
+ */
+export function sessionRequire() {
+  if (hasSourceCheckout()) {
+    const sourceRoot = resolveSourceRoot()
+    const pkgDir = join(sourceRoot, 'packages', 'session', 'session-persistence-jsonl')
+    return createRequire(join(pkgDir, 'package.json'))
+  }
+  const pkgDir = join(DSH_HOME, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-session')
+  return createRequire(join(pkgDir, 'package.json'))
+}
+
+/**
+ * Build a SessionPersistenceJsonl instance bound to the real session root.
+ * Uses the COMPILED packages (lib/) so behaviour matches the running server.
+ * Returns the resolved mode so callers can report which backend they used.
+ */
+export function loadPersistence(root = defaultSessionsRoot()) {
+  const { require, mode } = persistenceRequire()
+  const cordisName = mode === 'npm' ? '@deepseek-ai/cordis' : 'cordis'
+  const { Context } = require(cordisName)
+  const { SessionPersistenceJsonl } = require('@deepseek-ai/dsh-session-persistence-jsonl')
+  const ctx = new Context()
+  ctx.sessions = { list: () => [] } // no live sessions in a diagnostic context
+  const persistence = new SessionPersistenceJsonl(ctx, { root, compression: 'zstd' })
+  return { persistence, root, mode, sourceRoot: mode === 'source' ? resolveSourceRoot() : undefined }
+}
+
+/** Enumerate every session log under the root (project dir -> session dir). */
+export async function enumerateSessionLogs(root = defaultSessionsRoot()) {
+  const { readdir } = await import('node:fs/promises')
+  const logs = []
+  // 首次运行/空安装可能没有 sessions 根目录：视为无会话，而非崩溃
+  let projects
+  try {
+    projects = await readdir(root, { withFileTypes: true })
+  } catch {
+    return logs
+  }
+  for (const project of projects
+    .filter(e => e.isDirectory()).map(e => join(root, e.name))) {
+    for (const dir of (await readdir(project, { withFileTypes: true }))
+      .filter(e => e.isDirectory()).map(e => join(project, e.name))) {
+      const log = join(dir, 'session.jsonl.zstd')
+      const plain = join(dir, 'session.jsonl')
+      const exists = await import('node:fs/promises').then(fs => Promise.all([
+        fs.access(log).then(() => true, () => false),
+        fs.access(plain).then(() => true, () => false),
+      ]))
+      if (exists[0]) logs.push({ id: dir.split('/').pop(), project, dir, log, compression: 'zstd' })
+      else if (exists[1]) logs.push({ id: dir.split('/').pop(), project, dir, log: plain, compression: 'none' })
+    }
+  }
+  return logs
+}

--- a/skills/dsh-session-recovery/scripts/repair-session-log.mjs
+++ b/skills/dsh-session-recovery/scripts/repair-session-log.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * repair-session-log.mjs — lossless repair of a corrupt session log.
+ *
+ * Repairs the classic corruption: a session.jsonl.zstd that was recompressed
+ * as a SINGLE zstd frame (e.g. by a stock `zstd` CLI run). DSH requires the
+ * first frame to contain exactly the header line, and every later frame to end
+ * on a record boundary. This script re-frames the byte-identical plaintext
+ * using the SAME compressor DSH uses (node:zlib zstdCompress +
+ * ZSTD_c_checksumFlag=1), then validates with the DSH reader itself before
+ * swapping in place (reversibly: the original is kept as .orig-in-place until
+ * every check passes).
+ *
+ * Usage:
+ *   node repair-session-log.mjs --id <session-id>
+ *   node repair-session-log.mjs --dir <path-to-session-dir-or-log>
+ *   [--root <sessions-root>] [--backup-dir <dir>] [--lines-per-frame N]
+ *
+ * Exit codes: 0 repaired & verified; 2 nothing to repair (already valid);
+ * 1 any failure (original file is left untouched on failure).
+ */
+import { parseArgs } from 'node:util'
+import { zstdCompress, zstdDecompressSync, constants } from 'node:zlib'
+import { promisify } from 'node:util'
+import { createRequire } from 'node:module'
+import { readFile, writeFile, rename, mkdir, copyFile, rm, access } from 'node:fs/promises'
+import { join } from 'node:path'
+import { loadPersistence, enumerateSessionLogs, sessionRequire } from './lib/dsh.mjs'
+
+const zstdCompressAsync = promisify(zstdCompress)
+const CHECKSUM_OPTIONS = { params: { [constants.ZSTD_c_checksumFlag]: 1 } }
+
+const { values } = parseArgs({
+  options: {
+    id: { type: 'string' },
+    dir: { type: 'string' },
+    root: { type: 'string' },
+    'backup-dir': { type: 'string' },
+    'lines-per-frame': { type: 'string' },
+  },
+})
+const linesPerFrame = Number(values['lines-per-frame'] ?? 200)
+
+function fail(msg) {
+  console.error(`ABORT: ${msg}`)
+  process.exit(1)
+}
+
+// --- locate the log file ---------------------------------------------------
+const { persistence, root } = loadPersistence(values.root)
+
+let target
+if (values.dir) {
+  const p = values.dir
+  const isLog = p.endsWith('session.jsonl.zstd') || p.endsWith('session.jsonl')
+  target = isLog ? p : join(p, 'session.jsonl.zstd')
+  try { await access(target) } catch { fail(`cannot access log: ${target}`) }
+} else if (values.id) {
+  const logs = await enumerateSessionLogs(values.root)
+  const matches = logs.filter(l => l.id === values.id)
+  if (matches.length === 0) fail(`no session log found for id ${values.id} under ${root}`)
+  if (matches.length > 1) fail(`session id ${values.id} appears in multiple project dirs: ${matches.map(m => m.project).join(', ')}`)
+  target = matches[0].log
+  if (matches[0].compression !== 'zstd') fail(`session ${values.id} is a plaintext log — frame repair not applicable`)
+} else {
+  fail('provide --id <session-id> or --dir <path>')
+}
+
+const EXPECTED_ID = values.id ?? target.split('/').pop()
+const SESSION_DIR = target.replace(/\/session\.jsonl\.zstd$/, '')
+const LOG = target
+const BACKUP_DIR = values['backup-dir'] ?? join(process.cwd(), 'backups', SESSION_DIR.split('/').pop())
+
+// --- 0. pre-check: nothing to repair when the file already validates ---------
+try {
+  const first = await persistence.readFirstZstdLine(LOG)
+  if (first.startsWith('{"type":"session"')) {
+    await persistence.readPrefix(LOG, EXPECTED_ID)
+    console.log(`ALREADY VALID: ${EXPECTED_ID} passes header + full-read checks — nothing to repair`)
+    process.exit(2)
+  }
+} catch {
+  // falls through to repair
+}
+
+// --- 1. decompress + integrity ---------------------------------------------
+const raw = await readFile(LOG)
+let plain
+try {
+  plain = zstdDecompressSync(raw)
+} catch (error) {
+  fail(`cannot decompress (is this really zstd?): ${error.message}`)
+}
+console.log(`decompressed ${raw.length} bytes -> ${plain.length} bytes plaintext`)
+
+const text = plain.toString('utf8')
+if (!text.endsWith('\n')) fail('plaintext does not end with a newline (torn tail) — refusing automatic repair')
+const lines = text.split('\n')
+lines.pop()
+console.log(`total lines: ${lines.length} (${lines.length - 1} rows after header)`)
+
+let header
+try {
+  header = JSON.parse(lines[0])
+} catch {
+  fail(`first line is not valid JSON: ${lines[0].slice(0, 120)}`)
+}
+if (header.type !== 'session' || header.id !== EXPECTED_ID) {
+  fail(`header id mismatch: file header says ${header.id}, expected ${EXPECTED_ID}`)
+}
+console.log(`header OK: id=${header.id} cwd=${header.cwd ?? '(none)'} createdAt=${new Date(header.createdAt).toISOString()}`)
+
+let bad = 0
+for (let i = 1; i < lines.length; i++) {
+  try { JSON.parse(lines[i]) } catch { bad++; if (bad <= 5) console.error(`line ${i + 1} not JSON: ${lines[i].slice(0, 120)}`) }
+}
+if (bad > 0) fail(`${bad} rows are not valid JSON — refusing to proceed`)
+
+// --- 2. backup -------------------------------------------------------------
+await mkdir(BACKUP_DIR, { recursive: true })
+const backupPath = join(BACKUP_DIR, 'session.jsonl.zstd.orig-corrupt')
+await copyFile(LOG, backupPath)
+console.log(`backup written: ${backupPath}`)
+
+// --- 3. rebuild with DSH framing -------------------------------------------
+const frames = []
+frames.push(await zstdCompressAsync(Buffer.from(lines[0] + '\n'), CHECKSUM_OPTIONS))
+const body = lines.slice(1)
+for (let i = 0; i < body.length; i += linesPerFrame) {
+  const chunk = body.slice(i, i + linesPerFrame).join('\n') + '\n'
+  frames.push(await zstdCompressAsync(Buffer.from(chunk, 'utf8'), CHECKSUM_OPTIONS))
+}
+const rebuilt = Buffer.concat(frames)
+console.log(`rebuilt: ${frames.length} frames, ${rebuilt.length} bytes (original ${raw.length})`)
+
+// --- 4. validate rebuilt bytes ---------------------------------------------
+const tmpPath = `${LOG}.repair-tmp`
+await writeFile(tmpPath, rebuilt, { mode: 0o600 })
+
+let firstLine
+try {
+  firstLine = await persistence.readFirstZstdLine(tmpPath)
+} catch (error) {
+  await rm(tmpPath, { force: true })
+  fail(`readFirstZstdLine() failed on rebuilt file: ${error.message}`)
+}
+if (!firstLine.startsWith('{"type":"session"')) {
+  await rm(tmpPath, { force: true })
+  fail(`rebuilt header frame is not a session header`)
+}
+console.log(`header frame OK`)
+
+// --- 4b. reversible swap ----------------------------------------------------
+const inPlaceOrig = `${LOG}.orig-in-place`
+await rename(LOG, inPlaceOrig)
+await rename(tmpPath, LOG)
+
+const restore = async () => {
+  await rename(LOG, tmpPath).catch(() => {})
+  await rename(inPlaceOrig, LOG).catch(() => {})
+}
+
+// --- 4c. full read at canonical path + element-wise compare -----------------
+let prefix
+try {
+  prefix = await persistence.readPrefix(LOG, EXPECTED_ID)
+} catch (error) {
+  await restore()
+  fail(`persistence.readPrefix() failed on repaired file (original restored): ${error.message}`)
+}
+
+// 双路径解析 dsh-session：源码 checkout（A/B）→ 源码 packages/；npm 安装 → profile 闭包
+const { decodeStorageRecord } = sessionRequire('@deepseek-ai/dsh-session')
+const unpacked = []
+for (let i = 1; i < lines.length; i++) {
+  for (const event of decodeStorageRecord(JSON.parse(lines[i]))) unpacked.push(event)
+}
+console.log(`readPrefix: ${prefix.events.length} events; original plaintext decodes to ${unpacked.length} events`)
+
+if (prefix.events.length !== unpacked.length) {
+  await restore()
+  fail(`event count mismatch: repaired ${prefix.events.length} vs original ${unpacked.length} (original restored)`)
+}
+let mismatch = -1
+for (let i = 0; i < prefix.events.length; i++) {
+  if (prefix.events[i].seq !== unpacked[i].seq || prefix.events[i].type !== unpacked[i].type) { mismatch = i; break }
+}
+if (mismatch >= 0) {
+  await restore()
+  fail(`event mismatch at index ${mismatch} (original restored)`)
+}
+const firstEvent = prefix.events[0]
+const lastEvent = prefix.events[prefix.events.length - 1]
+console.log(`first event: seq=${firstEvent.seq} type=${firstEvent.type}`)
+console.log(`last event:  seq=${lastEvent.seq} type=${lastEvent.type}`)
+console.log(`element-wise check OK: ${prefix.events.length} events identical to original plaintext`)
+
+await rm(inPlaceOrig, { force: true })
+console.log(`original corrupt file removed (backup kept at ${backupPath})`)
+
+// --- 5. final whole-root check ---------------------------------------------
+let headers
+try {
+  headers = await persistence.list()
+} catch (error) {
+  fail(`persistence.list() still throws after swap: ${error.message}`)
+}
+if (!headers.some(h => h.id === EXPECTED_ID)) fail(`persistence.list() does not include ${EXPECTED_ID} after swap`)
+console.log(`FINAL CHECK: persistence.list() OK — ${headers.length} sessions visible`)
+console.log('REPAIR COMPLETE')

--- a/skills/dsh-session-recovery/scripts/restart-dsh-web.sh
+++ b/skills/dsh-session-recovery/scripts/restart-dsh-web.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# restart-dsh-web.sh — gracefully restart `dsh web` and wait until it serves.
+#
+# WHY: the workspace registry builds its session index only at startup. After
+# repairing session logs you MUST restart the server, or the GUI keeps showing
+# "0 sessions". The new server is nohup'd so it survives this script (and any
+# agent process) exiting.
+#
+# Usage:
+#   sh restart-dsh-web.sh [old-pid] [port] [start-dir]
+# Defaults: old-pid = current listener on the port; port = 3080;
+#           start-dir = cwd of the old listener (falls back to $HOME).
+set -u
+
+PORT="${2:-3080}"
+LOG=/tmp/dsh-web-restart.log
+
+# Detect the old listener (and its cwd) unless a pid was given.
+OLD_PID="${1:-}"
+if [ -z "$OLD_PID" ]; then
+  OLD_PID=$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -1)
+fi
+START_DIR="${3:-}"
+if [ -z "$START_DIR" ] && [ -n "$OLD_PID" ]; then
+  START_DIR=$(lsof -a -p "$OLD_PID" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p')
+fi
+START_DIR="${START_DIR:-$HOME}"
+echo "[$(date +%H:%M:%S)] old pid=${OLD_PID:-none} port=$PORT start-dir=$START_DIR"
+
+if [ -n "$OLD_PID" ]; then
+  echo "[$(date +%H:%M:%S)] sending SIGTERM to $OLD_PID"
+  kill -TERM "$OLD_PID" 2>/dev/null || true
+  waited=0
+  while [ "$waited" -lt 45 ]; do
+    if ! lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then break; fi
+    waited=$((waited + 1)); sleep 1
+  done
+  if lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "[$(date +%H:%M:%S)] did not exit after ${waited}s, sending SIGKILL"
+    kill -9 "$OLD_PID" 2>/dev/null || true
+    sleep 2
+  fi
+fi
+
+echo "[$(date +%H:%M:%S)] starting dsh web from $START_DIR"
+cd "$START_DIR" || { echo "cd $START_DIR failed"; exit 1; }
+nohup dsh web > "$LOG" 2>&1 &
+NEW_PID=$!
+echo "[$(date +%H:%M:%S)] new server pid $NEW_PID (log: $LOG)"
+
+for i in $(seq 1 120); do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
+  if [ "$code" = "200" ]; then
+    echo "[$(date +%H:%M:%S)] UP after ${i}s (HTTP $code)"
+    exit 0
+  fi
+  sleep 1
+done
+echo "[$(date +%H:%M:%S)] SERVER NOT UP after 120s"
+tail -80 "$LOG"
+exit 1

--- a/skills/dsh-session-recovery/scripts/validate-sessions.mjs
+++ b/skills/dsh-session-recovery/scripts/validate-sessions.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * validate-sessions.mjs — per-file header validation.
+ *
+ * For every session log under the DSH session root, run the SAME first-frame
+ * check the server runs inside persistence.list(): the first zstd frame must
+ * decompress to exactly one line (the session header). A single failing file
+ * makes the real list() throw and hides EVERY session in the GUI.
+ *
+ * Usage:
+ *   node validate-sessions.mjs [--root <sessions-root>]
+ * Exit code 0 when all files pass, 1 when any fail.
+ */
+import { parseArgs } from 'node:util'
+import { loadPersistence, enumerateSessionLogs } from './lib/dsh.mjs'
+
+const { values } = parseArgs({
+  options: {
+    root: { type: 'string' },
+  },
+})
+
+const { persistence } = loadPersistence(values.root)
+const logs = await enumerateSessionLogs(values.root)
+if (logs.length === 0) {
+  console.log(`no session logs found under ${values.root ?? '~/.dsh/sessions'}`)
+  process.exit(0)
+}
+
+let pass = 0
+let fail = 0
+for (const entry of logs) {
+  if (entry.compression !== 'zstd') {
+    console.log(`SKIP ${entry.id} (plaintext jsonl, no frame check)`)
+    pass++
+    continue
+  }
+  try {
+    const first = await persistence.readFirstZstdLine(entry.log)
+    const header = JSON.parse(first)
+    if (header.type !== 'session') throw new Error('first frame is not a session header')
+    const ok = header.id === entry.id
+    console.log(`${ok ? 'OK  ' : 'BAD '} ${entry.id}  header.id=${header.id} cwd=${header.cwd ?? '-'}${ok ? '' : '  <-- id mismatch with directory name!'}`)
+    if (!ok) fail++
+    else pass++
+  } catch (error) {
+    console.error(`FAIL ${entry.id}: ${error.message}`)
+    console.error(`     ${entry.log}`)
+    fail++
+  }
+}
+console.log(`\nRESULT: ${pass} pass, ${fail} fail`)
+process.exit(fail > 0 ? 1 : 0)


### PR DESCRIPTION
## 做了什么
把独立仓库 dsh-skill-session-recovery 的 skill 并入 dsh-harness-ops 运维工具箱（2026-08-11 合并决策）：
- `skills/dsh-session-recovery/`（SKILL.md + scripts + references）整体迁入
- README 更新：组件表 3→4、能力地图、安装节、场景 J 引用改内部、相邻项目记录

## 为什么
dsh-harness-ops 定位是 DSH 运维工具箱（AB 轮换 + 自愈 + 续接），会话丢失诊断/修复同属运维组件，结构上应归入本仓库；此前以外部仓库+README 链接引用，不一致。

## 验收/测试状态
skill 为纯目录拷贝（无代码 import 交叉），安装机制 cp -r 不变；README 渲染已人工核对。