### PR TITLE
docs(i18n): bilingual docs — README.en.md, switcher, English SKILL descriptions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,427 @@
+# dsh-harness-ops — DeepSeek Harness Ops Toolbox (self-healing + version rotation)
+
+English | [中文](README.md)
+
+> **This repo is DSH's "ops self-healing toolbox"**: it keeps the harness recovering
+> automatically on crash, upgrade, and switchover — no manual intervention. Each of the
+> four components owns one job:
+>
+> | Component | Type | What it does |
+> |---|---|---|
+> | **`skills/dsh-snapshot-ab`** | skill | Daily upstream-snapshot A/B dual-slot rotation — "switch to the right version" on upgrade |
+> | **`skills/dsh-web-guard`** | skill | Self-healing guard — auto-restarts web within 10s of it dying |
+> | **`skills/dsh-session-recovery`** | skill | Session-loss diagnosis — locate & losslessly repair "0 sessions" / corrupted logs |
+> | **`plugins/dsh-restart-recover`** | cordis plugin | Restart continuation — an interrupted turn resumes automatically |
+>
+> Together they answer four questions: **who brings web back up when it dies? Does work
+> continue after restart? What if sessions seem lost? How do we switch versions safely
+> when the official release arrives?** They complement each other:
+> `ab.sh switch/rollback` kills web → `dsh-web-guard` brings it back → `dsh-restart-recover` continues the turn.
+>
+> > Formerly `dsh-skill-snapshot-ab` (renamed 2026-08-11) — the repo grew from a
+> > pure AB-rotation skill into a mixed "skill + plugin" toolbox, so the old name no
+> > longer fit. The skill directory name `dsh-snapshot-ab` is unchanged (it is the skill
+> > trigger name and ab.sh install path; renaming it would break the mechanism).
+>
+> This README is the **human-readable operations manual** (scenario-based, every command
+> included). Agents read each skill's `SKILL.md`.
+
+---
+
+## 📦 Capability map
+
+```
+dsh-harness-ops (this repo)
+├── skills/dsh-snapshot-ab/        AB rotation: official snapshots in A/B dual slots, old version kept as fallback, atomic switch after acceptance
+│   └── scripts/ab.sh              main command (status/discover/prepare/verify/switch/confirm/rollback)
+├── skills/dsh-web-guard/          self-healing guard: launchd/systemd hosted, brings web up within 10s of a free port
+│   └── scripts/install.sh         cross-platform install (macOS launchd / Linux systemd)
+├── skills/dsh-session-recovery/   session-loss diagnosis: 0 sessions/corrupted logs → locate → lossless repair → restart
+│   └── scripts/                   validate-sessions / repair-session-log / check-all-sessions
+└── plugins/dsh-restart-recover/   restart-continuation plugin: detects interrupted on agent/created → auto-injects continuation
+    └── src/index.ts               cordis plugin (listens agent/created, zero dsh-track dependency)
+```
+
+**The most-used entries**:
+- Check status: `$AB status`
+- Daily upgrade: `$AB discover → prepare → switch --yes → confirm`
+- Self-heal check: `kill $(lsof -ti :3080)` → auto-restart within 10s → session continues (no manual step)
+
+---
+
+## 0. Mental model first (AB rotation)
+
+```
+~/.local/bin/dsh  (PATH launcher)
+   └─> ~/.dsh/source/current   ← symlink pointing at the "currently active" slot
+            └─> slot-a/  ── old version (20260809 snapshot + local fix)    ← current production
+            └─> slot-b/  ── new version (20260810 snapshot, built+accepted) ← candidate
+```
+
+- **Production (http://127.0.0.1:3080) always runs the slot that `current` points to.**
+- Switch = one atomic `ln -sfn current <slot>` + restart `dsh web`.
+- A/B is a **slot identity** (fixed directory names), the **content rotates daily**: the old
+  version occupies one slot, the new snapshot goes into the other slot.
+- Both slots can run processes simultaneously (on different ports), but they share
+  `~/.dsh`'s sessions/storages — **one production instance stays resident; the other slot is
+  used only for acceptance/occasional inspection (read-only, close it after)**, see Scenario E.
+
+Convention: `$AB` below means `~/.dsh/skills/dsh-snapshot-ab/scripts/ab.sh` (present once the skill is installed).
+
+---
+
+## 1. Install
+
+```sh
+# 1) Install the skills into the default scan directory
+mkdir -p ~/.dsh/skills && cp -r skills/dsh-snapshot-ab ~/.dsh/skills/
+cp -r skills/dsh-session-recovery ~/.dsh/skills/   # session-recovery skill (diagnose/repair session-log corruption)
+
+# 2) Configure (auto-read on first run; see skills/dsh-snapshot-ab/references/ab-config.example.json)
+#    Usually you only confirm extensions (extension repo paths) and the web port in ab-config.json
+vi ~/.dsh/source/ab-config.json
+
+# 3) Verify
+$AB status
+```
+
+`ab-config.json` key fields: `upstream` (official repo), `extensions[]` (extension list:
+repo/relink/build commands), `web.port` (staging smoke port, default 3081),
+`web.productionPort` (default 3080), `web.smokeClientIds` (client-manifest assertion),
+**`acceptance`** (acceptance switch, below).
+
+### Acceptance mode switch (`acceptance`)
+
+```json
+"acceptance": {
+  "mode": "manual",                    // "manual" (default; you must confirm before switching) | "auto" (switch once e2e passes)
+  "e2e": {
+    "enabled": true,                   // requires agent-browser on PATH
+    "checks": [ { "id": "@deepseek-ai/dsh-track", "selector": "#dsh-track-fab", "expect": "present" } ]
+  }
+}
+```
+
+- **`e2e`**: opens the candidate in a real browser and asserts these UI elements exist —
+  proof that the client plugin **actually renders** (a manifest row ≠ mounted in the browser;
+  today's ◆ panel incident is exactly that case).
+- **`mode: manual`**: `switch` still requires `--yes` (user confirmation); **`mode: auto`**:
+  once e2e passes it counts as user authorization, and `switch` no longer asks for
+  interactive confirmation (it still writes handoff and restarts web). Changeable anytime;
+  in auto mode `switch` refuses to run if e2e has not passed.
+
+---
+
+## 2. Scenario manual (follow the story; commands are copy-paste ready)
+
+### Scenario A · First deployment: adopt the currently running version as slot-a
+
+> Goal: let the mechanism take over the existing install — the running version becomes slot A,
+> mechanism state is persisted. **Does not restart the service.**
+
+```sh
+$AB status        # confirm current points where expected, slots empty, phase=idle
+$AB init --yes    # create slot-a worktree + pnpm install + full build (build:lib+build:web, a few minutes)
+                  # on completion current -> slot-a; the running service is unaffected (new slot takes effect at next restart)
+$AB status        # slot a* has content, current=a, phase=idle
+```
+
+`init` runs only once. It does a **full build** of the adopted slot (`dsh web` depends on
+`lib/` and `apps/web/dist`; a fresh worktree lacks these gitignored artifacts). A build
+failure aborts without touching `current`.
+
+### Scenario B · Daily start (the same every day)
+
+```sh
+dsh web           # start production. Never specify A/B — it runs the slot `current` points to
+```
+
+- The start/restart command is simply `dsh web` (or the PATH launcher), from any directory.
+- See which version is running: `readlink ~/.dsh/source/current` or `$AB status`.
+- Confirm health: `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3080/` → `200`.
+
+### Scenario C · Official released a new snapshot → daily rotation (core flow)
+
+> The official ships a new `snapshots/...` branch every day. Goal: **without touching
+> production**, build the new snapshot, mount our extensions, accept it, and only then
+> switch with your approval.
+
+```sh
+# 1) Check status
+$AB status                 # who is in production, phase, extension dirty-file count
+
+# 2) See what the official shipped today
+$AB discover               # fetch upstream → list snapshot branches → point out the next candidate + diff summary vs current
+                           # output like: next candidate: snapshots/20260810T155924Z-8ec407cd64
+
+# 3) Build in the "non-current" slot + mount extensions + smoke (never touches production)
+$AB prepare                # auto-picks the non-current slot; can also use explicit --slot b / --snapshot <ref>
+                           # pipeline: checkout snapshot → pnpm install --frozen-lockfile
+                           #        → build:lib + build:web
+                           #        → extension relink + generate tsconfig.ab.json + typecheck/build/test (DSH_SOURCE=candidate slot)
+                           #        → candidate bin/dsh web smoke on staging port (3081), HTTP 200
+                           # all green → phase=prepared, evidence written to ab-state.json
+                           # any step fails → restore extension relink, current untouched, phase back to idle (see Scenario G)
+
+# 4) Re-check (optional)
+$AB verify                 # rerun extension tests + smoke against the prepared candidate
+
+# 5) E2E frontend-mount acceptance (recommended — the only step that proves the frontend actually mounted)
+$AB e2e                    # open the candidate in a real browser, assert the UI elements in acceptance.e2e.checks exist
+                           # (e.g. #dsh-track-fab); on pass, evidence candidateEvidence.e2e.ok=true
+
+# 6) Switch — the mode decides whether this step needs your confirmation (see "acceptance mode")
+#    manual mode: $AB switch --yes after your approval
+#    auto mode: $AB switch once e2e passes (no interactive confirmation)
+$AB switch --yes           # the manual-mode way (auto mode: plain $AB switch)
+```
+
+**Three hard rules of `prepare`** (built into the script, but you should know them):
+- The candidate slot ≠ the current slot;
+- Before `confirm` after a switch, **refuse to recycle the rollback slot** (it is the only
+  fallback), unless `--force`;
+- Never switch if acceptance has not passed.
+
+### Scenario D · The moment of switch (session breaks; read this first)
+
+> What `switch` does: `current` atomically points to the candidate slot → verify the
+> launcher → restart `dsh web`. **Restart = the agent session you are in right now will
+> break** (the process hosting web is the one you run in). Expected, not a failure.
+
+**Before switching (3 things)**:
+```sh
+# ① Finish what you were saying / write a handoff (HANDOFF-snapshot-ab.md in the repo dir is the recovery entry)
+# ② Confirm the candidate is prepared and you accepted it
+$AB status                 # phase=prepared, candidate=b
+# ③ Want to keep the staging inspection instance? Close it first (see Scenario E) to avoid dual instances
+```
+
+**Switch**:
+```sh
+$AB switch --yes
+# output shows: CUTOVER → stop old web → start new web (nohup, log ~/.dsh/source/web.log) → HTTP 200
+# with dsh-web-guard installed: after ab.sh kills web the guard auto-brings up the new current (fallback, more reliable)
+```
+
+**After switching (restart done, open http://127.0.0.1:3080)**:
+```sh
+# ① Confirm the new version is running
+readlink ~/.dsh/source/current          # should = .../slot-b
+$AB status                              # current=b, phase=switched, confirmed=false
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3080/   # 200
+
+# ② ⚠️ Hard-refresh the browser (Cmd+Shift+R) — not a normal refresh!
+#    Old tabs hold the boot manifest loaded before the switch; new client plugins/panels
+#    (e.g. dsh-track's ◆) only appear after refresh. Real pitfall measured 2026-08-11:
+#    without refresh, the ◆ FAB never shows up.
+
+# ③ Use it for a few days / a while and confirm the new version is fine
+# ④ Fine → mark stable (unlocks recycling the rollback slot the next day)
+$AB confirm
+```
+
+**Panel (dsh-track) note**: the right panel defaults to **collapsed**; the ◆ FAB at the
+bottom-right expands it, and open/close state is kept in browser localStorage
+(`dsh.track.open`). If the panel "disappears", check in order: is dsh-track in the manifest →
+did you hard-refresh → did you click ◆.
+
+**Finding "the previous session"**: sessions all live on disk (`~/.dsh/sessions/`) and are
+re-indexed after restart — none are lost. Find the workspace's historical sessions (e.g.
+`~/source/dsh/explorer`) in the GUI; new sessions auto-read that directory's `AGENTS.md` →
+`HANDOFF-snapshot-ab.md` and know where to continue.
+
+### Scenario E · Temporarily inspect another version (guarded; don't run bare)
+
+> While production runs, you may want to see the other slot's UI (acceptance / comparison).
+> **Don't** run `~/.dsh/source/slot-b/bin/dsh web --port 3081` bare — use `stage`, which
+> detects and asks for confirmation.
+
+```sh
+$AB stage --slot b --port 3082            # foreground; Ctrl-C to stop
+$AB stage --slot a --port 3082 --keep --yes   # background (nohup); stop with the command it prints
+```
+
+`stage` behavior:
+- **Detects first**: an existing web instance (e.g. production 3080) → prints a warning
+  "second instance shares ~/.dsh, read-only view";
+- **Requires explicit `--yes`** confirmation before starting; without `--yes` it refuses and exits;
+- Target port taken → errors out, telling you to change `--port`;
+- `--keep` runs in background and prints the log path and stop command
+  (`kill $(lsof -tiTCP:<port> -sTCP:LISTEN)`).
+
+⚠️ During a temporary instance: **read-only**, don't run writes concurrently, close it when done.
+
+### Scenario F · New version has problems → rollback (available anytime)
+
+```sh
+$AB rollback --yes     # current points back to lastSwitch.previousTarget (the previous version) + restart web
+                       # also breaks the current session; continue from HANDOFF after restart
+$AB status             # phase=rolled-back, current back to the old slot
+```
+
+After rollback the old version (with local fixes) is fully preserved in the rollback slot;
+the new snapshot's problems can be investigated at leisure without affecting production.
+Manual fallback (when `ab.sh` is unavailable):
+```sh
+ln -sfn ~/.dsh/source/slot-a ~/.dsh/source/current
+kill <web pid> && cd ~/source/test-fakechris && nohup dsh web &
+```
+
+### Scenario G · prepare failed → troubleshoot
+
+Any `prepare` step failure: restores extension relink/tsconfig, leaves `current` untouched,
+phase back to `idle`. Locate by output:
+
+| Failed at | Meaning | What to do |
+|---|---|---|
+| `pnpm install failed` | deps not installed (network/lockfile) | check network; retry `$AB prepare` (auto `clean -fdx` fresh install) |
+| `harness build failed` | the new snapshot itself doesn't build | **upstream problem**, don't switch; report the build-output tail to the user/upstream |
+| `extension ... FAILED` | our extension is incompatible with the snapshot API (typecheck/build/test red) | this is what acceptance is for: **don't switch**; fix compatibility in the extension repo, rerun prepare |
+| `web smoke FAILED` | candidate web won't start / port taken | see smoke log (printed); port taken → change `web.port` |
+
+Retry after a common fix: `$AB prepare` (if the slot is already on the target snapshot with
+build artifacts it takes a **reuse fast path**, rerunning only extensions + smoke).
+
+### Scenario H · web won't start / missing build artifacts
+
+Symptoms: `dsh web` starts but the page is blank / complains about missing `lib`, `dist`.
+Cause: a new worktree's `lib/` and `apps/web/dist` are gitignored build artifacts —
+**`pnpm install` alone is not enough**.
+Fix:
+```sh
+cd ~/.dsh/source/<slot> && pnpm run build     # = build:lib (tsc+tsdown) + build:web (vite)
+```
+(`ab.sh init` and `ab.sh prepare` both do the full build automatically; only manually
+created worktrees need this.)
+
+### Scenario I · Port conflict / dual instance / lock held
+
+```sh
+# port taken
+lsof -iTCP:3081 -sTCP:LISTEN        # who holds it; stage/smoke → change --port / web.port
+# accidentally started a second instance (forgot to close)
+lsof -tiTCP:<port> -sTCP:LISTEN | xargs kill
+# lock held (another A/B operation in progress)
+# → prints "another A/B operation holds the lock"; wait for it to finish, or confirm no zombie and retry
+#   lock file: ~/.dsh/source/.ab.lock (flock semantics; python3 fcntl on macOS)
+```
+
+### Scenario J · Session "lost" after restart
+
+- Sessions are not lost: `~/.dsh/sessions/` is stored per workspace and re-indexed after
+  restart; the GUI sidebar should show all history.
+- Still can't see them? Use the in-repo `skills/dsh-session-recovery` skill (the dedicated
+  diagnose/repair flow).
+- Want to continue from the breakpoint: in a new session say "continue snapshot-ab"; the
+  agent loads this skill and reads `HANDOFF-snapshot-ab.md` / `USER-GUIDE-snapshot-ab.md`.
+
+### Scenario K · `current` or the launcher is broken (manual fallback)
+
+```sh
+# current missing / pointing wrong
+ln -sfn ~/.dsh/source/slot-a ~/.dsh/source/current   # point back at a known-good slot
+dsh --version                                        # verify the launcher starts
+
+# dsh on PATH broken
+ls -l ~/.local/bin/dsh                               # should -> ~/.dsh/source/current/bin/dsh
+ln -sfn ~/.dsh/source/current/bin/dsh ~/.local/bin/dsh
+```
+
+---
+
+## 3. Command quick reference
+
+| Command | What it does | What it touches |
+|---|---|---|
+| `$AB status` | layout/slots/phase/running web/extension dirty files | read-only |
+| `$AB discover` | fetch upstream, list snapshots, compute candidate, diff summary | fetch only |
+| `$AB init --yes` | adopt the current version as slot-a (worktree+install+**full build**), no restart | current |
+| `$AB prepare [--slot a\|b] [--snapshot <ref>] [--skip-web] [--keep] [--force]` | full candidate-slot pipeline (build+extensions+smoke), no production impact | candidate slot only |
+| `$AB verify` | rerun extension tests + smoke against the prepared candidate | read-only |
+| `$AB e2e [--slot a\|b] [--port N]` | **real-browser frontend-mount acceptance** (agent-browser asserts UI elements in `acceptance.e2e.checks`, e.g. `#dsh-track-fab`); prerequisite for auto-mode switch | temp instance + evidence |
+| `$AB stage --slot a\|b [--port N] [--keep]` | temporarily run a slot on a staging port (detects existing instance, requires `--yes`) | temp instance |
+| `$AB switch [--yes]` | atomically switch current → candidate + restart web (**breaks session**); manual mode needs `--yes`, auto mode needs e2e passed | current + service |
+| `$AB confirm` | mark current stable, unlock recycling the rollback slot next day | state |
+| `$AB rollback --yes` | point current back to the previous version + restart web (**breaks session**) | current + service |
+| `$AB cleanup [--yes] [dir...]` | list/remove old worktrees (never deletes the current slot) | worktrees |
+
+## 4. Layout and files
+
+| Path | What it is |
+|---|---|
+| `~/.dsh/source/current` | symlink → currently active slot (production = it) |
+| `~/.dsh/source/slot-a` / `slot-b` | the two slots (git worktrees sharing the main clone's object store) |
+| `~/source/test-fakechris` | main clone (object store + worktree host, **never a run target**) |
+| `~/.dsh/source/ab-state.json` | mechanism state (slots/current/phase/evidence/history) |
+| `~/.dsh/source/ab-config.json` | config (upstream/extension list/web ports) |
+| `~/.dsh/source/web.log` | production web restart log |
+| `~/.dsh/skills/dsh-snapshot-ab/` | this skill (SKILL.md = agent manual, references/ = design + user menu) |
+
+## 5. Design principles (why it is this way)
+
+1. **`current` symlink + git worktree**: isomorphic with the official `dsh-upgrade`; a switch
+   is one atomic `ln -sfn`; the main clone is only an object store and worktree host, never run.
+2. **Extensions live outside the slots, parameterized by slot**: extensions (e.g. dsh-track)
+   point at the target slot via `DSH_SOURCE` / generated `tsconfig.ab.json` / node_modules
+   symlinks → they can build and test against the new snapshot **before** the switch.
+3. **Acceptance gate**: install / build / extension tests / web smoke all green counts as
+   prepared; no acceptance, no switch. Smoke is not just HTTP 200 — `web.smokeClientIds`
+   asserts extension clients appear in `window.__DSH_BOOT__` (20260810 changed the declared
+   key `dshClient` to `dsh.client`; HTTP-200-only would miss that hole).
+4. **Single-instance principle**: the two slots share `~/.dsh` (sessions are append-only
+   shared files, storage KV is a single-process serial write chain) — one production
+   resident, the other slot only briefly started read-only for `stage`/smoke, closed after.
+5. **Confirmation window**: after `switch`, `confirm` is required before the rollback slot
+   may be recycled; rollback is always available.
+6. **Cooperating with `dsh-web-guard`**: the guard is an "out-of-band" self-healing daemon
+   (launchd/systemd hosted, PPID=1, brings web up within 10s of a free port) — after ab.sh
+   kills web the guard auto-starts the new current, no manual start needed; if ab.sh itself
+   starts successfully the guard doesn't interfere. After switch/restart **hard-refresh the
+   browser** to see new client panels.
+
+## 6. Relations with adjacent projects
+
+- Official `dsh-upgrade`: the integration flow that rebases onto upstream master
+  (occasionally used); this mechanism is the daily rotation of "official daily snapshot +
+  external extensions", and the two coexist.
+- **`dsh-web-guard` (another skill in this repo) + `plugins/dsh-restart-recover`**: the
+  complete restart self-healing — AB rotation handles "switching to the right version",
+  guard (the skill's daemon script) handles "web will definitely come up after restart",
+  restart-recover (cordis plugin) handles "the interrupted turn continues automatically
+  after restart" (listens to `agent/created`, injects a continuation message, zero user
+  input). They complement each other: `ab.sh switch/rollback` kills web → guard brings it
+  up → recover continues. The plugin was separated from dsh-track (2026-08-11) because,
+  like guard, it is a **platform-level self-healing capability** and should not be bound to
+  the business plugin dsh-track.
+- **`dsh-session-recovery` (in-repo skill, absorbed 2026-08-11)**: the session-loss
+  diagnose/repair/restart flow; incident retrospective at
+  `skills/dsh-session-recovery/references/incident-20260809-session-loss.md`.
+- Community `mainline-compat` (dsh-external-research): **compatibility monitoring/reporting**
+  between plugins and the day's mainline; it answers "can the plugin still be used", this
+  mechanism answers "how to switch over safely".
+- `dshx-update-check`: commit-SHA comparison **detection** of updates (detection only).
+
+---
+
+## Appendix: measured test log (2026-08-11)
+
+- `init` adopted the old version (be90233) as slot-a, `current` re-pointed, production not
+  restarted ✅
+- `prepare`+`verify` built the 20260810 snapshot (4cdb149) in slot-b: extension
+  typecheck/build/**75 tests all pass**, smoke **HTTP 200** ✅
+- The acceptance gate really caught an upstream change: the 20260810 snapshot removed the
+  `dsh web --workspace-root` flag (smoke adapted automatically) ✅
+- Mechanism bugs fixed: init missing full build (Scenario H), stage missing coexistence
+  guardrail (Scenario E), smoke leftover-process cleanup ✅
+- **20260810 upstream declared-key rename incident (fixed)**: the snapshot renamed the
+  client-modules declared key `dshClient` to `dsh.client`; extensions unadapted → host
+  plugin fine, extension tests all green, smoke 200, but the client panel disappeared. Fix:
+  extensions uniformly declare the new `dsh.client` key (no compat for old `dshClient`;
+  old versions retire with rotation) + acceptance gate gains **client-manifest assertion**
+  (`web.smokeClientIds`, parses `__DSH_BOOT__` and validates id by id) ✅
+- **Panel regression verification (real browser)**: after the fix, slot-b's `__DSH_BOOT__`
+  contains `@deepseek-ai/dsh-track`, `/plugins/.../client.js` 200, plugin apply() executes
+  (◆ FAB and panel DOM exist), clicking FAB expands the panel and pulls real data ✅
+- **"◆ missing after restart" = old tab not refreshed** (lesson): the boot manifest is read
+  at page load; after restart old tabs keep the old manifest; hard refresh (Cmd+Shift+R)
+  makes it appear. Written into both skills' verify/troubleshoot sections ✅

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # dsh-harness-ops — DeepSeek Harness 运维工具箱（自愈 + 版本轮换）
+[English](README.en.md) | 中文
+
 
 > **这个仓库是 DSH 的"运维自愈工具箱"**：让 harness 在崩溃、升级、切换时都能自动恢复、
 > 无需人工干预。四个组件各管一段：

--- a/skills/dsh-session-recovery/SKILL.md
+++ b/skills/dsh-session-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-session-recovery
-description: 诊断并修复 DeepSeek Harness 会话丢失/消失事故：GUI 侧边栏显示 "0 sessions"、会话列表为空、session 全部不见了、或出现 "corrupt Zstandard session log" / "first frame is not exactly one header line" / "torn JSONL record" 等校验错误。覆盖损坏 session 日志（session.jsonl.zstd）的定位与无损修复、备份与回滚、重启 dsh web 前写 handoff、修复后验证。当用户提到会话丢失、session 消失、0 sessions、日志损坏、重启后会话没了、或 session 相关校验报错时，务必使用本 skill，即使问题看起来像是"系统崩溃"或"integration 校验挂了"。
+description: 诊断并修复 DeepSeek Harness 会话丢失/消失事故：GUI 侧边栏显示 "0 sessions"、会话列表为空、session 全部不见了、或出现 "corrupt Zstandard session log" / "first frame is not exactly one header line" / "torn JSONL record" 等校验错误。覆盖损坏 session 日志（session.jsonl.zstd）的定位与无损修复、备份与回滚、重启 dsh web 前写 handoff、修复后验证。当用户提到会话丢失、session 消失、0 sessions、日志损坏、重启后会话没了、或 session 相关校验报错时，务必使用本 skill，即使问题看起来像是"系统崩溃"或"integration 校验挂了" English: diagnose and repair DeepSeek Harness session-loss incidents (0 sessions, empty session list, corrupted Zstandard session log, torn JSONL records); use whenever the user reports lost sessions, 0 sessions, corrupted logs, or session-related validation errors, even when it looks like a crash or a broken integration check。
 license: BSD-3-Clause
 metadata:
   version: 1.0.0

--- a/skills/dsh-snapshot-ab/SKILL.md
+++ b/skills/dsh-snapshot-ab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-snapshot-ab
-description: 每日上游快照的 A/B 双槽轮换机制。上游官方（dsh2026/test-fakechris）每天发布新的 snapshots/YYYYMMDDTHHMMSSZ-* 分支时，在保留当前运行版本（A 槽）不动的前提下，把新快照检出到另一个槽（B 槽），重新挂接我们的扩展（如 dsh-track），构建+验收通过后才原子切换 current 符号链接；下一天角色互换。当用户说"官方发了新 branch / 切换新快照 / 升级到今天的 snapshot / AB 双版本轮换 / 跑一下 daily 快照更新"时使用。
+description: 每日上游快照的 A/B 双槽轮换机制。上游官方（dsh2026/test-fakechris）每天发布新的 snapshots/YYYYMMDDTHHMMSSZ-* 分支时，在保留当前运行版本（A 槽）不动的前提下，把新快照检出到另一个槽（B 槽），重新挂接我们的扩展（如 dsh-track），构建+验收通过后才原子切换 current 符号链接；下一天角色互换。当用户说"官方发了新 branch / 切换新快照 / 升级到今天的 snapshot / AB 双版本轮换 / 跑一下 daily 快照更新"时使用 English: daily upstream-snapshot A/B dual-slot rotation; use when the user mentions a new official snapshot branch, switching or upgrading to today's snapshot, AB dual-version rotation, or a daily snapshot update。
 ---
 
 # DSH Snapshot A/B Rotation（快照 A/B 轮换）

--- a/skills/dsh-web-guard/SKILL.md
+++ b/skills/dsh-web-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-web-guard
-description: dsh web 自愈——重启自动拉起 + 自动继续。agent 运行在 dsh web 进程内，kill 掉 3080 等于杀掉自己，无法自救。本 skill 提供完整的重启自愈：① 守护（scripts/install.sh 装成系统服务，launchd/systemd，PPID=1）在 web 死后 10 秒内自动拉起；② 配套插件 @deepseek-ai/dsh-restart-recover（本项目的 plugins/ 目录）监听 agent/created，检测到上次 turn 被中断后自动注入续接消息，agent 带着中断上下文继续 —— 用户零输入。当用户说"重启 3080 / web 挂了怎么自动拉起来 / 切换后自己把自己拉起来 / kill 后不用手动启动 / 重启后自动继续 / 做重启守护"时使用。
+description: dsh web 自愈——重启自动拉起 + 自动继续。agent 运行在 dsh web 进程内，kill 掉 3080 等于杀掉自己，无法自救。本 skill 提供完整的重启自愈：① 守护（scripts/install.sh 装成系统服务，launchd/systemd，PPID=1）在 web 死后 10 秒内自动拉起；② 配套插件 @deepseek-ai/dsh-restart-recover（本项目的 plugins/ 目录）监听 agent/created，检测到上次 turn 被中断后自动注入续接消息，agent 带着中断上下文继续 —— 用户零输入。当用户说"重启 3080 / web 挂了怎么自动拉起来 / 切换后自己把自己拉起来 / kill 后不用手动启动 / 重启后自动继续 / 做重启守护"时使用 English: self-healing restart for dsh web — auto-restart when web dies (launchd/systemd guard) plus auto-continue of the interrupted turn; use when the user says "restart 3080", "web is down, bring it back", "restart after switchover", "no manual start after kill", "auto-continue after restart", or "make a restart guard"。
 ---
 
 # dsh-web-guard — dsh web 自愈（守护拉起 + 自动续接）


### PR DESCRIPTION
## 做了什么
按双语文档规范（中文主 + 英文对照 + 切换行，镜像官方 DSH 仓库做法）：
- 新增 `README.en.md`（运维手册完整英文翻译）
- `README.md` 顶部加切换行 `[English](README.en.md) | 中文`
- 三个 SKILL.md（dsh-snapshot-ab / dsh-web-guard / dsh-session-recovery）的 description 追加英文触发短语，保证英文/混写指令也能触发 skill

## 为什么
规范来源：官方仓库 docs/AGENTS.md 双语惯例；已写入全局 AGENTS.md（L6）。

## 验收/测试状态
README 渲染人工核对；frontmatter 仍为合法 YAML（description 单行含英文）。