### PR TITLE
feat(snapshot-ab): ab.sh notes — official agent-notes changelog between snapshots

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -33,7 +33,7 @@ English | [中文](README.md)
 ```
 dsh-harness-ops (this repo)
 ├── skills/dsh-snapshot-ab/        AB rotation: official snapshots in A/B dual slots, old version kept as fallback, atomic switch after acceptance
-│   └── scripts/ab.sh              main command (status/discover/prepare/verify/switch/confirm/rollback)
+│   └── scripts/ab.sh              main command (status/discover/notes/prepare/verify/switch/confirm/rollback)
 ├── skills/dsh-web-guard/          self-healing guard: launchd/systemd hosted, brings web up within 10s of a free port
 │   └── scripts/install.sh         cross-platform install (macOS launchd / Linux systemd)
 ├── skills/dsh-session-recovery/   session-loss diagnosis: 0 sessions/corrupted logs → locate → lossless repair → restart
@@ -152,6 +152,9 @@ $AB status                 # who is in production, phase, extension dirty-file c
 
 # 2) See what the official shipped today
 $AB discover               # fetch upstream → list snapshot branches → point out the next candidate + diff summary vs current
+                           # + official changelog (when the candidate is newer: agent notes added, the official "why")
+$AB notes                  # standalone changelog: default running tip → newest; shows the running pair when up to date
+                           # --full prints note bodies; --json pure JSON
                            # output like: next candidate: snapshots/20260810T155924Z-8ec407cd64
 
 # 3) Build in the "non-current" slot + mount extensions + smoke (never touches production)
@@ -334,7 +337,8 @@ ln -sfn ~/.dsh/source/current/bin/dsh ~/.local/bin/dsh
 | Command | What it does | What it touches |
 |---|---|---|
 | `$AB status` | layout/slots/phase/running web/extension dirty files | read-only |
-| `$AB discover` | fetch upstream, list snapshots, compute candidate, diff summary | fetch only |
+| `$AB discover` | fetch upstream, list snapshots, compute candidate, diff summary; official changelog (added agent notes) when the candidate is newer | fetch only |
+| `$AB notes [--from\|--to] [--full] [--json]` | official changelog between two snapshots (agent notes added under `.agents/notes/implemented`; default running tip → newest) | fetch only |
 | `$AB init --yes` | adopt the current version as slot-a (worktree+install+**full build**), no restart | current |
 | `$AB prepare [--slot a\|b] [--snapshot <ref>] [--skip-web] [--keep] [--force]` | full candidate-slot pipeline (build+extensions+smoke), no production impact | candidate slot only |
 | `$AB verify` | rerun extension tests + smoke against the prepared candidate | read-only |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ```
 dsh-harness-ops（本仓库）
 ├── skills/dsh-snapshot-ab/        AB 轮换：官方快照 A/B 双槽，旧版保底、验收后原子切换
-│   └── scripts/ab.sh              主命令（status/discover/prepare/verify/switch/confirm/rollback）
+│   └── scripts/ab.sh              主命令（status/discover/notes/prepare/verify/switch/confirm/rollback）
 ├── skills/dsh-web-guard/          自愈守护：launchd/systemd 托管，端口空闲 10s 内拉起 web
 │   └── scripts/install.sh         跨平台安装（macOS launchd / Linux systemd）
 ├── skills/dsh-session-recovery/  会话丢失诊断：0 sessions/日志损坏 → 定位 → 无损修复 → 重启
@@ -139,7 +139,10 @@ $AB status                 # 谁在生产、phase、扩展脏文件数
 
 # 2) 看官方今天发了什么
 $AB discover               # fetch 上游 → 列出快照分支 → 指出下一个候选 + 与当前的 diff 摘要
+                           # + 官方 changelog（候选更新时：新增的 agent notes，即官方"为什么"）
                            # 输出类似：next candidate: snapshots/20260810T155924Z-8ec407cd64
+$AB notes                  # 单独打印 changelog：默认 运行 tip → 最新；无新快照时显示当前运行对
+                           # --full 连笔记正文；--json 纯 JSON
 
 # 3) 在"非当前槽"构建 + 挂扩展 + 冒烟（全程不动生产）
 $AB prepare                # 自动选非当前槽；也可显式 --slot b / --snapshot <ref>
@@ -307,7 +310,8 @@ ln -sfn ~/.dsh/source/current/bin/dsh ~/.local/bin/dsh
 | 命令 | 作用 | 动什么 |
 |---|---|---|
 | `$AB status` | 布局/槽/phase/运行中 web/扩展脏文件 | 只读 |
-| `$AB discover` | fetch 上游、列快照、算候选、diff 摘要 | 只 fetch |
+| `$AB discover` | fetch 上游、列快照、算候选、diff 摘要；候选更新时附官方 changelog（新增 agent notes） | 只 fetch |
+| `$AB notes [--from\|--to] [--full] [--json]` | 两个快照间的官方 changelog（`.agents/notes/implemented` 新增笔记；默认 运行 tip → 最新） | 只 fetch |
 | `$AB init --yes` | 收编当前版本为 slot-a（worktree+install+**完整构建**），不重启 | current |
 | `$AB prepare [--slot a\|b] [--snapshot <ref>] [--skip-web] [--keep] [--force]` | 候选槽全流水线（构建+扩展+冒烟），不动生产 | 仅候选槽 |
 | `$AB verify` | 对 prepared 候选重跑扩展测试+冒烟 | 只读 |

--- a/skills/dsh-snapshot-ab/SKILL.md
+++ b/skills/dsh-snapshot-ab/SKILL.md
@@ -28,7 +28,22 @@ description: 每日上游快照的 A/B 双槽轮换机制。上游官方（dsh20
 ## 每日工作流
 
 1. **`ab.sh status`** — 确认当前状态（slots、phase、running web、扩展脏文件数）。phase 应为 `idle` 且 current 已设置；若未初始化先做 `ab.sh init --yes`（把当前运行版本收编为 slot-a：新建 worktree + `pnpm install` + **完整构建 build:lib+build:web**（数分钟，`dsh web` 依赖构建产物），不重启服务）。
-2. **`ab.sh discover`** — fetch 上游，列出快照分支，指出下一个候选。人工（agent）阅读 snapshot diff，判断上游这天的变化对扩展/我们的使用是否有影响（可参考已有的 snapshot-diff 研究流程）。
+2. **`ab.sh discover`** — fetch 上游，列出快照分支，指出下一个候选，并打印与当前的 diff stat；当候选**比当前更新**时，还会打印官方 changelog（见下）。人工（agent）按「**先读官方 changelog，再读代码 diff**」的顺序分析：notes 给出意图（为什么、放弃了什么），diff 给出事实；两者对不上时以代码为准并回报。参考已有的 snapshot-diff 研究流程与产出物（`snapshot-diff-report-*.md`）。
+
+### 官方 changelog：agent notes（先读这个，再读 diff）
+
+官方仓库**没有** CHANGELOG 文档，但强制每个非平凡改动写一篇 **Agent Note**
+（`.agents/notes/implemented/<class>/yyyy-mm-dd-<topic>.md`，class ∈ feature /
+bug-fix / simplification / architecture / process / testing；每篇带 `.zh.md` +
+`.i18n.yaml`，统一格式 Problem / Decision / Consequences / Alternatives）。因此
+**两个快照之间新增的 notes 就是官方对该快照的 changelog**。
+
+- `ab.sh discover`：候选比当前新时直接打印这段 changelog（当前 tip → 候选）。
+- 单独查看：**`ab.sh notes`** — 默认 运行中快照 tip → 最新快照；没有新快照时
+  自动显示「当前运行对」（另一槽 → 当前）。`--full` 连笔记正文一起打印；
+  `--from/--to <ref>` 指定区间；`--json` 输出结构化列表（纯 JSON，stdout 无日志）。
+- 脚本/agent 流程：读 changelog 条目 → 按需 `git show <ref>:<path>` 看全文 →
+  代码 diff 验证 → 写 `snapshot-diff-report-YYYYMMDD.md`。
 3. **`ab.sh prepare [--slot b] [--skip-web]`** — 在**非当前槽**执行完整流水线：
    - 检出候选快照（worktree reset / 新建）→ `pnpm install --frozen-lockfile` → harness `build:lib`（+`build:web`，除非 `--skip-web`）。
    - 扩展挂接：relink node_modules → 候选槽；生成 `tsconfig.ab.json`（把扩展 tsconfig 里的 `/Users/chris/.dsh/source/current` 前缀替换为候选槽）；用 `DSH_SOURCE=<候选槽>` 跑扩展的 typecheck/build/test；同步 skills 到 `~/.dsh/skills/`。

--- a/skills/dsh-snapshot-ab/references/mechanism-design.md
+++ b/skills/dsh-snapshot-ab/references/mechanism-design.md
@@ -96,7 +96,8 @@ refs/heads/dsh-staging/20260809T141636Z             ← 官方 staging（含后�
 | 命令 | 作用 | 改什么 |
 |---|---|---|
 | `status` | 布局/槽/phase/运行中 web/扩展脏文件 | 只读 |
-| `discover` | fetch 上游、列快照、算候选、diff stat | 只 fetch |
+| `discover` | fetch 上游、列快照、算候选、diff stat；候选比当前新时附官方 changelog（新增 agent notes） | 只 fetch |
+| `notes [--from \|--to <ref>] [--full] [--json]` | 打印两个快照间的官方 changelog（`.agents/notes/implemented` 新增笔记；默认 运行 tip → 最新，无新快照时显示当前运行对） | 只 fetch |
 | `init --yes` | 把当前运行版本收编为 slot-a（新 worktree + 装依赖 + **完整构建** build:lib+build:web + 重指 current，**不重启**） | current |
 | `prepare [--slot a\|b]` | 候选槽：检出快照 → install → build → 扩展挂接构建测试 → 冒烟（3081） | 仅候选槽 |
 | `verify` | 对 prepared 候选重跑扩展测试 + 冒烟 | 只读 |

--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -9,6 +9,11 @@
 # Commands:
 #   status                       print layout, slots, phase, running server
 #   discover [--json]            fetch upstream, list snapshot branches, diff
+#                                stat + official changelog (added agent notes)
+#   notes [--from <ref>] [--to <ref>] [--full] [--json]
+#                                official changelog between two snapshots: the
+#                                agent notes (.agents/notes/implemented) added
+#                                in between (defaults: running tip -> newest)
 #   init [--yes]                 adopt the running version as slot-a (no restart)
 #   prepare [--slot a|b] [--snapshot <ref>] [--skip-web] [--keep] [--force]
 #                                build+verify the next snapshot in the other slot
@@ -43,15 +48,19 @@ CMD="${1:-help}"
 shift || true
 
 FLAG_SLOT=""; FLAG_SNAPSHOT=""; FLAG_PORT=""; FLAG_SKIP_WEB=0; FLAG_KEEP=0; FLAG_FORCE=0; FLAG_YES=0; FLAG_JSON=0
+FLAG_FROM=""; FLAG_TO=""; FLAG_FULL=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --slot) FLAG_SLOT="${2:-}"; shift 2 ;;
     --snapshot) FLAG_SNAPSHOT="${2:-}"; shift 2 ;;
     --port) FLAG_PORT="${2:-}"; shift 2 ;;
+    --from) FLAG_FROM="${2:-}"; shift 2 ;;
+    --to) FLAG_TO="${2:-}"; shift 2 ;;
     --skip-web) FLAG_SKIP_WEB=1; shift ;;
     --keep) FLAG_KEEP=1; shift ;;
     --force) FLAG_FORCE=1; shift ;;
     --yes) FLAG_YES=1; shift ;;
+    --full) FLAG_FULL=1; shift ;;
     --json) FLAG_JSON=1; shift ;;
     *) ab_die "unknown argument: $1 (see: ab.sh help)" ;;
   esac
@@ -121,13 +130,94 @@ cmd_discover() {
       local from to
       from=$(ab_slot_tip "$(ab_current_slot)")
       to=$(git -C "$AB_MAIN" rev-parse "$cand")
-      [ -n "$from" ] && ab_log "diff stat vs current (${from:0:8} -> ${to:0:8}):" \
-        && git -C "$AB_MAIN" diff --stat "$from" "$to" | tail -15
+      if [ -n "$from" ]; then
+        ab_log "diff stat vs current (${from:0:8} -> ${to:0:8}):" \
+          && git -C "$AB_MAIN" diff --stat "$from" "$to" | tail -15
+        # the notes changelog only reads forward; show it for the normal daily
+        # case (candidate NEWER than current), not for an older leftover
+        local cand_ts cur_ts
+        cand_ts=$(printf '%s' "$(ab_snapshot_branch "$cand")" | sed -E 's/.*([0-9]{8}T[0-9]{6}Z).*/\1/')
+        cur_ts=$(printf '%s' "$cur_snap" | sed -E 's/.*([0-9]{8}T[0-9]{6}Z).*/\1/')
+        if [ -n "$cand_ts" ] && [ -n "$cur_ts" ] && [ "$cand_ts" \> "$cur_ts" ]; then
+          ab_log "official changelog (added agent notes) ${from:0:8} -> ${to:0:8}:"
+          ab_notes_changelog "$from" "$to" 0
+        fi
+      fi
     fi
   else
     ab_log "no new snapshot beyond the two slots (up to date)"
   fi
   if [ "$FLAG_JSON" = "1" ]; then printf '%s\n' "$refs" | sed 's#^refs/remotes/origin/##' | jq -R . | jq -s .; fi
+}
+
+# ab_note_key — normalize an agent-note path to its canonical English .md key so
+# the .md/.zh.md/.i18n.yaml triplet dedupes to one entry.
+ab_note_key() { sed -E 's/\.(zh\.md|i18n\.yaml|md)$//' | awk '{ print $0 ".md" }' | sort -u; }
+
+# ab_notes_changelog <from> <to> [full] — official changelog between two
+# snapshots: the agent notes added in between. The official repo REQUIRES one
+# Agent Note per non-trivial change (`.agents/notes/implemented/<class>/
+# yyyy-mm-dd-<topic>.md` + .zh.md + .i18n.yaml, each with Problem/Decision/
+# Consequences/Alternatives), so the notes ADDED between two snapshots are the
+# official changelog for that pair. Triplets are deduped to the English .md.
+ab_notes_changelog() {
+  local from="$1" to="$2" full="${3:-0}"
+  [ -n "$from" ] && [ -n "$to" ] || ab_die "notes: need both from and to"
+  local keys mods dels props rejs
+  keys=$(git -C "$AB_MAIN" diff --name-only --diff-filter=A "$from" "$to" -- .agents/notes/implemented 2>/dev/null | ab_note_key) || true
+  mods=$(git -C "$AB_MAIN" diff --name-only --diff-filter=M "$from" "$to" -- .agents/notes/implemented 2>/dev/null | ab_note_key | wc -l | tr -d ' ') || true
+  dels=$(git -C "$AB_MAIN" diff --name-only --diff-filter=D "$from" "$to" -- .agents/notes/implemented 2>/dev/null | ab_note_key | wc -l | tr -d ' ') || true
+  props=$(git -C "$AB_MAIN" diff --name-only --diff-filter=A "$from" "$to" -- .agents/notes/proposed 2>/dev/null | ab_note_key | wc -l | tr -d ' ') || true
+  rejs=$(git -C "$AB_MAIN" diff --name-only --diff-filter=A "$from" "$to" -- .agents/notes/rejected 2>/dev/null | ab_note_key | wc -l | tr -d ' ') || true
+  local n=0 key cls date_title title
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    n=$((n+1))
+    cls=$(printf '%s' "$key" | sed -E 's#\.agents/notes/implemented/([^/]+)/.*#\1#')
+    date_title=$(printf '%s' "$key" | sed -E 's#.*/([0-9]{4}-[0-9]{2}-[0-9]{2}-[^/]+)\.md$#\1#')
+    title=$(git -C "$AB_MAIN" show "$to:$key" 2>/dev/null | sed -n '1s/^# Agent Note: //p') || true
+    ab_log "  $cls  $date_title${title:+  —  $title}"
+    if [ "$full" = "1" ]; then
+      git -C "$AB_MAIN" show "$to:$key" 2>/dev/null | sed 's/^/       /' || true
+    fi
+  done <<< "$keys"
+  ab_log "notes added: $n, modified: $mods, removed: $dels (implemented); proposed +$props, rejected +$rejs"
+}
+
+cmd_notes() {
+  # Official changelog between two snapshots (defaults: running tip -> newest).
+  [ -n "$AB_MAIN" ] || ab_die "no main clone resolved"
+  git -C "$AB_MAIN" fetch origin 2>&1 | tail -1 || true
+  local from to newest cur_snap cur_tip other_tip from_def=0 to_def=0
+  from="$FLAG_FROM"; to="$FLAG_TO"
+  newest=$(ab_snapshot_refs | head -1 || true)
+  [ -n "$newest" ] || ab_die "no upstream snapshot branches"
+  cur_snap=$(ab_slot_snapshot "$(ab_current_slot)")
+  cur_tip=$(ab_slot_tip "$(ab_current_slot)")
+  other_tip=$(ab_slot_tip "$(ab_other_slot)")
+  if [ -z "$to" ]; then to=$(ab_snapshot_branch "$newest"); to_def=1; fi
+  if [ -z "$from" ]; then
+    from_def=1
+    if [ -n "$cur_tip" ]; then from="$cur_tip"; else from=$(ab_snapshot_branch "$(ab_snapshot_refs | tail -1 || true)"); fi
+  fi
+  # no new snapshot beyond the running one: show the running pair instead
+  # (older/other slot -> current), oldest-first like the diff stat.
+  if [ "$to_def" = "1" ] && [ "$from_def" = "1" ] && [ "$to" = "$cur_snap" ] && [ -n "$other_tip" ]; then
+    ab_warn "newest snapshot is the running version — showing the running pair (override with --from/--to)"
+    from="$other_tip"; to="$cur_tip"
+  fi
+  git -C "$AB_MAIN" rev-parse --verify "$from^{commit}" >/dev/null 2>&1 || ab_die "unknown from ref: $from"
+  git -C "$AB_MAIN" rev-parse --verify "$to^{commit}" >/dev/null 2>&1 || ab_die "unknown to ref: $to"
+  if [ "$FLAG_JSON" = "1" ]; then
+    local keys
+    keys=$(git -C "$AB_MAIN" diff --name-only --diff-filter=A "$from" "$to" -- .agents/notes/implemented 2>/dev/null | ab_note_key) || true
+    jq -n --arg from "$from" --arg to "$to" \
+      --argjson added "$(printf '%s' "$keys" | jq -R -s 'split("\n") | map(select(length > 0))')" \
+      '{ from: $from, to: $to, added: $added }'
+    return 0
+  fi
+  ab_log "official changelog (agent notes) ${from:0:8} -> ${to:0:8}:"
+  ab_notes_changelog "$from" "$to" "$FLAG_FULL"
 }
 
 cmd_init() {
@@ -546,6 +636,7 @@ cmd_help() {
 case "$CMD" in
   status) cmd_status ;;
   discover) cmd_discover ;;
+  notes) cmd_notes ;;
   init) cmd_init ;;
   prepare) cmd_prepare ;;
   verify) cmd_verify ;;


### PR DESCRIPTION
## 做了什么

官方仓库没有 CHANGELOG 文档，但强制每个非平凡改动写一篇 Agent Note（`.agents/notes/implemented/<class>/yyyy-mm-dd-<topic>.md`，en/zh/i18n 三件套，Problem/Decision/Consequences/Alternatives）。因此**两个快照之间新增的 notes 就是官方对该快照的 changelog**。本 PR 把它固化进 dsh-snapshot-ab：

1. 新子命令 **`ab.sh notes`**：列出两个快照间新增的 agent notes（默认 运行 tip → 最新；无新快照时自动显示当前运行对）。`--full` 打印笔记正文；`--from/--to <ref>` 指定区间；`--json` 纯 JSON（stdout 无日志污染）。
2. **`ab.sh discover` 集成**：候选比当前新（按快照时间戳比较）时直接打印该 changelog；旧的遗留候选只显示 diff stat（避免反向误导）。
3. 文档同步：SKILL.md 每日工作流（先读官方 changelog 再读 diff）+ mechanism-design.md 命令表 + README(zh/en) 能力地图/命令速查。

## 为什么

每日例行要「提炼官方改了什么东西」，之前只能从 1986 个文件的 diff 反推。notes 直接给出官方意图（为什么、放弃了什么、踩了什么坑），先读 notes 再验证 diff 快得多也准得多。

## 验收/测试

- `bash -n` 通过；`ab.sh help` 含新命令。
- 实测（当前槽状态）：`ab.sh notes` → 23 篇（20260809→20260810 对，方向正确、三件套去重）；`--json` → jq 可解析纯 JSON；`--full` → 正文输出；`--from c638319 --to 4cdb149` → 正常；`discover` → 旧候选时正确跳过 changelog。