### PR TITLE
fix(skills): valid YAML frontmatter for bilingual descriptions + snapshot-ab trigger phrases

### DIFF
--- a/skills/dsh-session-recovery/SKILL.md
+++ b/skills/dsh-session-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-session-recovery
-description: 诊断并修复 DeepSeek Harness 会话丢失/消失事故：GUI 侧边栏显示 "0 sessions"、会话列表为空、session 全部不见了、或出现 "corrupt Zstandard session log" / "first frame is not exactly one header line" / "torn JSONL record" 等校验错误。覆盖损坏 session 日志（session.jsonl.zstd）的定位与无损修复、备份与回滚、重启 dsh web 前写 handoff、修复后验证。当用户提到会话丢失、session 消失、0 sessions、日志损坏、重启后会话没了、或 session 相关校验报错时，务必使用本 skill，即使问题看起来像是"系统崩溃"或"integration 校验挂了" English: diagnose and repair DeepSeek Harness session-loss incidents (0 sessions, empty session list, corrupted Zstandard session log, torn JSONL records); use whenever the user reports lost sessions, 0 sessions, corrupted logs, or session-related validation errors, even when it looks like a crash or a broken integration check。
+description: "诊断并修复 DeepSeek Harness 会话丢失/消失事故：GUI 侧边栏显示 \"0 sessions\"、会话列表为空、session 全部不见了、或出现 \"corrupt Zstandard session log\" / \"first frame is not exactly one header line\" / \"torn JSONL record\" 等校验错误。覆盖损坏 session 日志（session.jsonl.zstd）的定位与无损修复、备份与回滚、重启 dsh web 前写 handoff、修复后验证。当用户提到会话丢失、session 消失、0 sessions、日志损坏、重启后会话没了、或 session 相关校验报错时，务必使用本 skill，即使问题看起来像是\"系统崩溃\"或\"integration 校验挂了\" English: diagnose and repair DeepSeek Harness session-loss incidents (0 sessions, empty session list, corrupted Zstandard session log, torn JSONL records); use whenever the user reports lost sessions, 0 sessions, corrupted logs, or session-related validation errors, even when it looks like a crash or a broken integration check。"
 license: BSD-3-Clause
 metadata:
   version: 1.0.0

--- a/skills/dsh-snapshot-ab/SKILL.md
+++ b/skills/dsh-snapshot-ab/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: dsh-snapshot-ab
-description: 每日上游快照的 A/B 双槽轮换机制。上游官方（dsh2026/test-fakechris）每天发布新的 snapshots/YYYYMMDDTHHMMSSZ-* 分支时，在保留当前运行版本（A 槽）不动的前提下，把新快照检出到另一个槽（B 槽），重新挂接我们的扩展（如 dsh-track），构建+验收通过后才原子切换 current 符号链接；下一天角色互换。当用户说"官方发了新 branch / 切换新快照 / 升级到今天的 snapshot / AB 双版本轮换 / 跑一下 daily 快照更新"时使用 English: daily upstream-snapshot A/B dual-slot rotation; use when the user mentions a new official snapshot branch, switching or upgrading to today's snapshot, AB dual-version rotation, or a daily snapshot update。
+description: >-
+  每日上游快照的 A/B 双槽轮换 + 官方改动提炼机制。上游官方（dsh2026/test-fakechris）每天发布新的
+  snapshots/YYYYMMDDTHHMMSSZ-* 分支：日常分析——跑当天快照与前一天快照的 diff，先读官方 changelog
+  （新增 agent notes，ab.sh notes）再验证代码，产出 snapshot-diff-report 报告；升级轮换——新快照
+  检出到另一槽、挂接扩展（dsh-track 等）、构建+验收通过后才原子切换 current，下一天角色互换。
+  用户说"分析今天和昨天的快照 / 今天官方改了啥 / 官方改了什么 / 看下今天的 changelog / 官方发新快照
+  了吗"触发日常分析；说"官方发了新 branch / 切换新快照 / 升级到今天的 snapshot / AB 双版本轮换 /
+  跑一下 daily 快照更新"触发升级轮换。English: daily upstream-snapshot A/B dual-slot rotation plus
+  an official-change digest; use when the user asks what the official side changed between today's and
+  yesterday's snapshots (run the diff, read the agent-notes changelog first), mentions a new official
+  snapshot branch, switching or upgrading to today's snapshot, AB dual-version rotation, or a daily
+  snapshot update。
 ---
 
 # DSH Snapshot A/B Rotation（快照 A/B 轮换）
@@ -10,10 +21,24 @@ description: 每日上游快照的 A/B 双槽轮换机制。上游官方（dsh20
 ## 何时用
 
 - 官方发布了新快照，要把运行版本换成新的（每天例行）。
+- 需要知道官方某天快照改了什么（日常分析：changelog + diff + 影响评估）。
 - 需要评估某个快照对我们扩展（dsh-track 等）的兼容性（构建/测试/冒烟）。
 - 需要回滚到上一个快照。
 
 不要用本 skill 做 rebase 到 master 的升级（那是 `dsh-upgrade`）、或修改 harness 源码（那是 `dsh-customize`）。
+
+## 用户怎么触发（对话说法 → 动作）
+
+你不必碰命令行；在对话里说下面的话，agent 会自动跑对应的 ab.sh 流程：
+
+| 你说 | agent 做 |
+|---|---|
+| "官方今天发新快照了吗" / "看下今天的快照" | `ab.sh discover`（列快照分支；候选更新时自动附官方 changelog） |
+| "分析一下今天和昨天的快照" / "今天官方改了啥" / "提炼一下官方改了什么" / "看看今天的 changelog" | `ab.sh discover` + `ab.sh notes`（官方 changelog）→ 按「notes 意图 → 代码 diff 事实」分析 → 产出 `snapshot-diff-report-YYYYMMDD.md` 并给影响评估 |
+| "跑一下 daily 快照更新" / "升级到今天的快照" | 完整轮换：`discover → prepare → e2e/验收 → switch --yes → confirm` |
+| "切换新快照" / "AB 双版本轮换" | 轮换/回滚流程（`prepare/switch/rollback`；重启 web 前先写 handoff） |
+
+注意：说"官方改了啥"一类话术时**默认只分析、不改运行版本**；要真正升级再说"升级/切换/跑一下 daily"。
 
 ## 布局（先解析，别假设）
 

--- a/skills/dsh-web-guard/SKILL.md
+++ b/skills/dsh-web-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-web-guard
-description: dsh web 自愈——重启自动拉起 + 自动继续。agent 运行在 dsh web 进程内，kill 掉 3080 等于杀掉自己，无法自救。本 skill 提供完整的重启自愈：① 守护（scripts/install.sh 装成系统服务，launchd/systemd，PPID=1）在 web 死后 10 秒内自动拉起；② 配套插件 @deepseek-ai/dsh-restart-recover（本项目的 plugins/ 目录）监听 agent/created，检测到上次 turn 被中断后自动注入续接消息，agent 带着中断上下文继续 —— 用户零输入。当用户说"重启 3080 / web 挂了怎么自动拉起来 / 切换后自己把自己拉起来 / kill 后不用手动启动 / 重启后自动继续 / 做重启守护"时使用 English: self-healing restart for dsh web — auto-restart when web dies (launchd/systemd guard) plus auto-continue of the interrupted turn; use when the user says "restart 3080", "web is down, bring it back", "restart after switchover", "no manual start after kill", "auto-continue after restart", or "make a restart guard"。
+description: "dsh web 自愈——重启自动拉起 + 自动继续。agent 运行在 dsh web 进程内，kill 掉 3080 等于杀掉自己，无法自救。本 skill 提供完整的重启自愈：① 守护（scripts/install.sh 装成系统服务，launchd/systemd，PPID=1）在 web 死后 10 秒内自动拉起；② 配套插件 @deepseek-ai/dsh-restart-recover（本项目的 plugins/ 目录）监听 agent/created，检测到上次 turn 被中断后自动注入续接消息，agent 带着中断上下文继续 —— 用户零输入。当用户说\"重启 3080 / web 挂了怎么自动拉起来 / 切换后自己把自己拉起来 / kill 后不用手动启动 / 重启后自动继续 / 做重启守护\"时使用 English: self-healing restart for dsh web — auto-restart when web dies (launchd/systemd guard) plus auto-continue of the interrupted turn; use when the user says \"restart 3080\", \"web is down, bring it back\", \"restart after switchover\", \"no manual start after kill\", \"auto-continue after restart\", or \"make a restart guard\"。"
 ---
 
 # dsh-web-guard — dsh web 自愈（守护拉起 + 自动续接）


### PR DESCRIPTION
## 根因（重要）

四个本地 skill（dsh-snapshot-ab / dsh-web-guard / dsh-session-recovery / dsh-track）的 frontmatter **全部是非法 YAML**：双语 description 以 `...时使用 English: ...` 结尾，而 plain scalar 里的 `: `（冒号+空格）会提前终止标量。harness 的 skill-local provider（`parseFrontmatter`）遇到解析异常直接 `return undefined`（日志 `invalid YAML frontmatter`）——**这些 skill 从未被 skill 系统加载，目录里看不到、按名字/描述都无法触发**。已用 harness 自带 `yaml@2.9.0` 复现确认。

## 改动（本 PR 覆盖本仓库 3 个 skill）

1. **dsh-snapshot-ab**：description 重写为合法块标量，并新增「日常分析」触发话术（`分析今天和昨天的快照 / 今天官方改了啥 / 官方改了什么 / 看下今天的 changelog / 官方发新快照了吗` → diff + ab.sh notes + 报告；升级话术不变）；正文新增「用户怎么触发（对话说法 → 动作）」映射表——用户聊天里直接说触发句，agent 自动跑 ab.sh。
2. **dsh-web-guard / dsh-session-recovery**：description 双引号包裹（内部引号转义），文本与原意图逐字节一致（已验证）。

## 验收

- 三个 frontmatter 用 PyYAML 和 harness `yaml@2.9.0` 均解析通过；name/description 正确读出。
- web-guard / session-recovery 解析后的 description 与修改前逐字节一致（len 689/705）。
- dsh-track（另一仓库 dsh-involute）同缺陷，单独 PR 修。