### PR TITLE
docs(readme): document the daily official-change analysis (changelog → diff → report)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -44,8 +44,18 @@ dsh-harness-ops (this repo)
 
 **The most-used entries**:
 - Check status: `$AB status`
+- Daily analysis (what did the official change): `$AB discover` / `$AB notes` (official changelog) → see "Scenario C′"
 - Daily upgrade: `$AB discover → prepare → switch --yes → confirm`
 - Self-heal check: `kill $(lsof -ti :3080)` → auto-restart within 10s → session continues (no manual step)
+
+**Official-change digest (daily analysis)**: the official repo ships **no CHANGELOG**, but it
+**requires** an **Agent Note** per non-trivial change (`.agents/notes/implemented/<class>/
+yyyy-mm-dd-<topic>.md`, class ∈ feature / bug-fix / simplification / architecture / process /
+testing, each with a `.zh.md` + `.i18n.yaml`, format Problem / Decision / Consequences /
+Alternatives). So **the notes added between two snapshots ARE the official changelog for that
+pair**. `ab.sh discover` (printed automatically when the candidate is newer) and `ab.sh notes`
+(standalone) list that changelog directly — read the official "why" first, then verify against
+the code diff, and produce `snapshot-diff-report-YYYYMMDD.md`.
 
 ---
 
@@ -139,6 +149,43 @@ dsh web           # start production. Never specify A/B — it runs the slot `cu
 - The start/restart command is simply `dsh web` (or the PATH launcher), from any directory.
 - See which version is running: `readlink ~/.dsh/source/current` or `$AB status`.
 - Confirm health: `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3080/` → `200`.
+
+### Scenario C′ · What did the official change → daily analysis (changelog → diff → report)
+
+**Analysis only — never touches the running version.** To learn what a snapshot changed and
+what it affects, just say "**analyze today's and yesterday's snapshots** / what did the official
+change today / look at today's changelog" in the conversation (equivalent commands below):
+
+```sh
+# 1) Official changelog (the "why, and what we gave up") — read this BEFORE the diff
+$AB discover               # list snapshot branches; prints the official changelog automatically
+                           #   when the candidate is newer (current tip → candidate)
+$AB notes                  # standalone: default running tip → newest snapshot; shows the running
+                           #   pair when up to date
+                           #   --full     print note bodies (Problem/Decision/Consequences/Alternatives)
+                           #   --from/--to <ref>   explicit range
+                           #   --json     pure JSON (no log lines on stdout)
+                           # e.g. feature  2026-08-08-windows-acl-restricted-token-sandbox  —  Windows sandbox rung: ...
+
+# 2) Verify against the code diff (notes are intent, diff is fact; when they disagree,
+#    trust the code and report)
+#    git diff <old-tip> <new-tip> for deeper dives
+
+# 3) Output: snapshot-diff-report-YYYYMMDD.md (the five change themes + core changes +
+#    impact assessment for dsh-track / our usage)
+```
+
+**Trigger phrases** (say these in conversation; no CLI needed):
+
+| You say | The agent does |
+|---|---|
+| "did the official release a new snapshot today" / "look at today's snapshot" | `ab.sh discover` (list snapshots + official changelog when the candidate is newer) |
+| "analyze today's and yesterday's snapshots" / "what did the official change today" / "look at today's changelog" | `discover` + `notes` → analyze "notes intent → diff facts" → write the report + impact assessment |
+| "run the daily snapshot update" / "upgrade to today's snapshot" | full rotation: `discover → prepare → acceptance → switch → confirm` |
+| "switch to the new snapshot" / "AB dual-version rotation" | rotation/rollback flow (write a handoff before restarting web) |
+
+> "what did the official change"-style phrases default to **analysis only**; say "upgrade /
+> switch / run daily" to actually rotate.
 
 ### Scenario C · Official released a new snapshot → daily rotation (core flow)
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,17 @@ dsh-harness-ops（本仓库）
 
 **日常用得最多的入口**：
 - 看状态：`$AB status`
+- 每日分析（官方改了啥）：`$AB discover` / `$AB notes`（官方 changelog）→ 见「场景 C′」
 - 每日升级：`$AB discover → prepare → switch --yes → confirm`
 - 自愈验证：`kill $(lsof -ti :3080)` → 10s 内自动拉起 → 会话自动继续（无需手动）
+
+**官方改动提炼（每日分析）**：官方仓库没有 CHANGELOG 文档，但**强制**每个非平凡改动写一篇
+**Agent Note**（`.agents/notes/implemented/<class>/yyyy-mm-dd-<topic>.md`，class ∈ feature /
+bug-fix / simplification / architecture / process / testing，每篇带 `.zh.md` + `.i18n.yaml`，
+内容为 Problem / Decision / Consequences / Alternatives）。因此**两个快照之间新增的笔记就是
+官方对该快照的 changelog**。`ab.sh discover`（候选更新时自动打印）+ `ab.sh notes`（单独查看）
+把这段 changelog 直接列出来——先读官方"为什么"，再读代码 diff 验证，产出
+`snapshot-diff-report-YYYYMMDD.md`。
 
 ---
 
@@ -127,6 +136,38 @@ dsh web           # 启动生产。永远不需要指定 A/B —— 跑的是 cu
 - 启动/重启命令就是 `dsh web`（或 PATH 上的 launcher），从任何目录都行。
 - 想看现在跑的是哪个版本：`readlink ~/.dsh/source/current` 或 `$AB status`。
 - 想确认服务健康：`curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3080/` → `200`。
+
+### 场景 C′ · 官方改了啥 → 每日分析（changelog → diff → 报告）
+
+**只分析，不改运行版本。** 想知道官方某天快照改了什么、影响什么，在对话里直接说
+「**分析一下今天和昨天的快照** / 今天官方改了啥 / 官方改了什么 / 看下今天的 changelog」即可
+触发（等价命令如下）：
+
+```sh
+# 1) 官方 changelog（"为什么、放弃了什么"）——先读这个，再读 diff
+$AB discover               # 列快照分支；候选比当前新时直接打印官方 changelog（当前 tip → 候选）
+$AB notes                  # 单独打印：默认 运行 tip → 最新快照；没有新快照时自动显示"当前运行对"
+                           #   --full   连笔记正文（Problem/Decision/Consequences/Alternatives）
+                           #   --from/--to <ref>   指定区间
+                           #   --json   纯 JSON（stdout 无日志，机器可解析）
+                           # 输出形如：feature  2026-08-08-windows-acl-restricted-token-sandbox  —  Windows sandbox rung: ...
+
+# 2) 代码 diff 验证（notes 是意图，diff 是事实；两者对不上以代码为准并回报）
+#    git diff <old-tip> <new-tip> 按需深挖
+
+# 3) 产出：snapshot-diff-report-YYYYMMDD.md（官方改动五大主题 + 核心改动 + 对 dsh-track/我们的影响评估）
+```
+
+**触发话术速查**（对话里说，不用碰命令行）：
+
+| 你说 | agent 做 |
+|---|---|
+| "官方今天发新快照了吗" / "看下今天的快照" | `ab.sh discover`（列快照 + 候选更新时附官方 changelog） |
+| "分析一下今天和昨天的快照" / "今天官方改了啥" / "官方改了什么" / "看下今天的 changelog" | `discover` + `notes` → 按「notes 意图 → diff 事实」分析 → 产出报告 + 影响评估 |
+| "跑一下 daily 快照更新" / "升级到今天的快照" | 完整轮换：`discover → prepare → 验收 → switch → confirm` |
+| "切换新快照" / "AB 双版本轮换" | 轮换/回滚流程（重启 web 前先写 handoff） |
+
+> 说"官方改了啥"一类话术时**默认只分析、不改运行版本**；要真正升级再说"升级/切换/跑一下 daily"。
 
 ### 场景 C · 官方发了新快照 → 每日轮换（核心流程）
 


### PR DESCRIPTION
## 做了什么

`ab.sh notes` / `ab.sh discover` 的 changelog 能力（PR #3）和触发话术流程（PR #4）此前只在 SKILL.md 里，本次把它写进人读的操作手册（README 双语）：

1. **能力地图**新增「官方改动提炼（每日分析）」块：官方没有 CHANGELOG，但强制每个非平凡改动写 Agent Note（`.agents/notes/implemented/...`），两个快照间新增的笔记 = 官方 changelog；`discover`/`notes` 直接列出；先读 notes（意图）再读 diff（事实），产出 `snapshot-diff-report-YYYYMMDD.md`。
2. **新增「场景 C′ · 官方改了啥 → 每日分析」**：完整命令（`discover` / `notes --full/--from/--to/--json`）、分析顺序、报告产物、**触发话术速查表**（对话里说 X → agent 做 Y），并注明「官方改了啥」默认只分析、升级才轮换。
3. README.en.md 同步（双语，符合 L6）。

## 验收

- 中文/英文结构对称（场景 C′ 均在场景 C 前）；`git diff --stat` 2 文件 +88 行。
- 无 skill 文件改动，无需同步 `~/.dsh/skills`。
