### PR TITLE
fix(snapshot-ab): boot slots without bin/dsh (removed in the 20260811 snapshot)

### DIFF
--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -506,7 +506,8 @@ cmd_switch() {
   ln -sfn "$dir" "$AB_SOURCE/current"
   [ "$(readlink "$AB_SOURCE/current")" = "$dir" ] || ab_die "symlink cutover failed"
   ab_log "  verifying launcher boots from new current..."
-  dsh --version >/dev/null 2>&1 || { ab_warn "launcher boot failed — rolling back symlink immediately"; ln -sfn "$prev_target" "$AB_SOURCE/current"; ab_die "rollback symlink restored to $prev_target"; }
+  # shellcheck disable=SC2086
+  $(ab_boot_cmd "$dir") --version >/dev/null 2>&1 || { ab_warn "launcher boot failed — rolling back symlink immediately"; ln -sfn "$prev_target" "$AB_SOURCE/current"; ab_die "rollback symlink restored to $prev_target"; }
   ab_state_set --arg slot "$slot" --arg prev "$prev_slot" --arg prevtarget "$prev_target" --arg at "$at" --arg snap "$(ab_state_get '.candidateSnapshot')" '
     .current = $slot | .phase = "switched" | .confirmed = false
     | .lastSwitch = { at: $at, from: $prev, to: $slot, previousTarget: $prevtarget, snapshot: $snap }
@@ -537,7 +538,8 @@ cmd_rollback() {
   ab_log "ROLLBACK: current -> $prev_target"
   ln -sfn "$prev_target" "$AB_SOURCE/current"
   [ "$(readlink "$AB_SOURCE/current")" = "$prev_target" ] || ab_die "symlink rollback failed"
-  dsh --version >/dev/null 2>&1 || { ab_warn "launcher boot failed after rollback"; }
+  # shellcheck disable=SC2086
+  $(ab_boot_cmd "$prev_target") --version >/dev/null 2>&1 || { ab_warn "launcher boot failed after rollback"; }
   # map the target back to a slot if it is one
   local slot="" s
   for s in a b; do
@@ -577,11 +579,14 @@ ab_restart_web() {
   # nohup'd dsh web must find `node` on PATH: a bare `dsh` from a non-login
   # shell fails with "exec: node: not found" (the launcher execs node). Pin the
   # node bin dir from the current shell and use the resolved launcher path.
-  local node_bin=""
+  local node_bin="" boot_dir
   command -v node >/dev/null 2>&1 && node_bin=$(dirname "$(command -v node)")
   log="$AB_SOURCE/web.log"
-  ab_log "  starting: nohup ${AB_LAUNCHER:-dsh} web (cwd $cwd, log $log)"
-  ( cd "$cwd" && PATH="${node_bin:+$node_bin:}$PATH" nohup "${AB_LAUNCHER:-dsh}" web >"$log" 2>&1 & echo $! > "$AB_SOURCE/web.pid" )
+  # restart boots the NEW current (the symlink was already cut over)
+  boot_dir=$(readlink "$AB_SOURCE/current" 2>/dev/null || echo "$AB_CURRENT")
+  ab_log "  starting: nohup $(ab_boot_cmd "$boot_dir") web (cwd $cwd, log $log)"
+  # shellcheck disable=SC2086
+  ( cd "$cwd" && PATH="${node_bin:+$node_bin:}$PATH" nohup $(ab_boot_cmd "$boot_dir") web >"$log" 2>&1 & echo $! > "$AB_SOURCE/web.pid" )
   i=0; code=000
   while [ "$i" -lt 180 ]; do
     code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:$port/" 2>/dev/null || echo 000)
@@ -618,11 +623,13 @@ cmd_stage() {
   fi
   ab_log "booting slot $slot (${dir}) web on http://127.0.0.1:$port — production instance keeps running; this one is READ-ONLY inspection."
   if [ "$FLAG_KEEP" = "1" ]; then
-    ( cd "$dir" && nohup ./bin/dsh web --port "$port" >"$AB_SOURCE/web-stage-$slot.log" 2>&1 & echo $! > "$AB_SOURCE/stage-$slot.pid" )
+    # shellcheck disable=SC2086
+    ( cd "$dir" && nohup $(ab_boot_cmd "$dir") web --port "$port" >"$AB_SOURCE/web-stage-$slot.log" 2>&1 & echo $! > "$AB_SOURCE/stage-$slot.pid" )
     ab_ok "staging server up (log $AB_SOURCE/web-stage-$slot.log, pid $(cat "$AB_SOURCE/stage-$slot.pid"))"
     ab_log "  stop it: kill \$(lsof -tiTCP:$port -sTCP:LISTEN)   # listener pid may differ from the wrapper"
   else
-    ( cd "$dir" && exec ./bin/dsh web --port "$port" )
+    # shellcheck disable=SC2086
+    ( cd "$dir" && exec $(ab_boot_cmd "$dir") web --port "$port" )
   fi
 }
 

--- a/skills/dsh-snapshot-ab/scripts/lib/acceptance.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/acceptance.sh
@@ -15,8 +15,9 @@ acc_e2e() {
   local allok=1 pid log i code sel id html
   command -v agent-browser >/dev/null 2>&1 || { ab_err "e2e: agent-browser not on PATH"; return 1; }
   log="$(mktemp -t dsh-ab-e2e.XXXXXX).log"
-  ab_log "e2e: booting $dir/bin/dsh web on $host:$port for browser checks (log $log)"
-  ( cd "$dir" && nohup ./bin/dsh web --port "$port" --host "$host" >"$log" 2>&1 & echo $! > "$log.pid" )
+  ab_log "e2e: booting $(ab_boot_cmd "$dir") web on $host:$port for browser checks (log $log)"
+  # shellcheck disable=SC2086
+  ( cd "$dir" && nohup $(ab_boot_cmd "$dir") web --port "$port" --host "$host" >"$log" 2>&1 & echo $! > "$log.pid" )
   pid=$(cat "$log.pid")
   i=0; code=000
   while [ "$i" -lt "$timeout" ]; do
@@ -103,14 +104,15 @@ acc_web_smoke() {
   # --workspace-root exists on some snapshots and was removed on others; ask the
   # candidate's own CLI before passing it (acceptance must not assume flags).
   ws_arg=""
-  if ( cd "$dir" && ./bin/dsh web --help 2>&1 | grep -q -- '--workspace-root' ); then
+  # shellcheck disable=SC2086
+  if ( cd "$dir" && $(ab_boot_cmd "$dir") web --help 2>&1 | grep -q -- '--workspace-root' ); then
     ws_arg="--workspace-root $(mktemp -d -t dsh-ab-ws.XXXXXX)"
   else
     ab_warn "  candidate's dsh web has no --workspace-root flag; smoke without it"
   fi
-  ab_log "smoke: $dir/bin/dsh web --port $port (log $log)"
+  ab_log "smoke: $(ab_boot_cmd "$dir") web --port $port (log $log)"
   # shellcheck disable=SC2086
-  ( cd "$dir" && nohup ./bin/dsh web --port "$port" --host "$host" $ws_arg >"$log" 2>&1 & echo $! > "$log.pid" )
+  ( cd "$dir" && nohup $(ab_boot_cmd "$dir") web --port "$port" --host "$host" $ws_arg >"$log" 2>&1 & echo $! > "$log.pid" )
   pid=$(cat "$log.pid")
   i=0
   while [ "$i" -lt "$timeout" ]; do

--- a/skills/dsh-snapshot-ab/scripts/lib/common.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/common.sh
@@ -140,6 +140,20 @@ ab_other_slot() {
 
 ab_is_initialized() { [ "$(ab_state_get '.current // ""')" != "" ]; }
 
+# ab_boot_cmd <dir> — command line that boots this slot's dsh CLI.
+# 0810-era slots ship bin/dsh (a tsx wrapper); the 20260811 snapshot removed it
+# (source-run without a managed installer), so fall back to the same recipe the
+# old wrapper used, anchored to the slot by absolute paths + the tsconfig hook.
+# Callers expand it UNQUOTED inside their subshell (paths contain no spaces).
+ab_boot_cmd() {
+  local dir="$1"
+  if [ -x "$dir/bin/dsh" ]; then
+    printf '%s\n' "$dir/bin/dsh"
+  else
+    printf 'env NODE_USE_ENV_PROXY=1 TSX_TSCONFIG_PATH=%s/tsconfig.json node --import %s/node_modules/tsx/dist/esm/index.mjs %s/apps/cli/src/bin.ts\n' "$dir" "$dir" "$dir"
+  fi
+}
+
 # ---- misc -------------------------------------------------------------------
 
 ab_now() { date -u +%Y%m%dT%H%M%SZ; }


### PR DESCRIPTION
## 为什么

20260811 快照移除了 `bin/dsh`（source-run without managed installer，官方入口改为 `pnpm dsh` = build + tsx 直启 `apps/cli/src/bin.ts`）。ab.sh 的冒烟/e2e/stage/restart/switch 校验全部依赖 `<slot>/bin/dsh`，导致 0811 的 `prepare` 在 web 冒烟阶段失败（`nohup: ./bin/dsh: No such file or directory`）。

## 改了什么

- `common.sh` 新增 **`ab_boot_cmd <dir>`**：槽里有 `bin/dsh`（0810 及更早）就用它；没有（0811+）就回退到旧 wrapper 的同一配方（`NODE_USE_ENV_PROXY=1 TSX_TSCONFIG_PATH=<dir>/tsconfig.json node --import <dir>/node_modules/tsx/dist/esm/index.mjs <dir>/apps/cli/src/bin.ts`，绝对路径锚定槽）。
- `acceptance.sh`：e2e 启动、`--workspace-root` 探测、web 冒烟启动全部改用它。
- `ab.sh`：switch/rollback 的 launcher 校验改用它；`ab_restart_web` 改为解析**新 current**（symlink 已切）后启动；`stage`（keep + 前台）改用它。

## 验收

- 对 0811 快照 `ab.sh prepare --slot a` **全链路通过**：扩展 dsh-track 154/154、冒烟 HTTP 200（2s）、client manifest 含 `@deepseek-ai/dsh-track`、证据落 state。
- `bash -n` 三个脚本全过。
