### PR TITLE
fix(snapshot-ab): slot-usable gates + layout check accept 20260811 (no bin/dsh)

### DIFF
--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -454,7 +454,7 @@ cmd_e2e() {
     [ -n "$slot" ] || slot=$(ab_current_slot)
   fi
   dir=$(ab_slot_dir "$slot")
-  [ -n "$dir" ] && [ -d "$dir/bin" ] || ab_die "slot $slot has no usable checkout ($dir)"
+  [ -n "$dir" ] && ab_slot_usable "$dir" || ab_die "slot $slot has no usable checkout ($dir)"
   wport="$FLAG_PORT"; [ -n "$wport" ] || wport=$(ab_config_get '.web.port // 3081')
   whost=$(ab_config_get '.web.host // "127.0.0.1"'); wtimeout=$(ab_config_get '.web.startupTimeoutSec // 180')
   ab_log "e2e acceptance for slot $slot ($dir)"
@@ -495,7 +495,7 @@ cmd_switch() {
   [ "$phase" = "prepared" ] || ab_die "nothing prepared (phase=$phase); run prepare first"
   slot=$(ab_state_get '.candidate'); [ -n "$slot" ] || ab_die "no candidate slot recorded"
   dir=$(ab_slot_dir "$slot")
-  [ -d "$dir/bin" ] || ab_die "candidate dir missing: $dir"
+  ab_slot_usable "$dir" || ab_die "candidate dir missing: $dir"
   prev_slot=$(ab_current_slot)
   prev_target=$(readlink "$AB_SOURCE/current" 2>/dev/null || echo "$AB_CURRENT")
   at=$(ab_now)
@@ -531,7 +531,7 @@ cmd_rollback() {
   local prev_target at
   prev_target=$(ab_state_get '.lastSwitch.previousTarget // ""')
   [ -n "$prev_target" ] || ab_die "no previous target recorded"
-  [ -d "$prev_target/bin" ] || ab_die "previous target missing: $prev_target"
+  ab_slot_usable "$prev_target" || ab_die "previous target missing: $prev_target"
   at=$(ab_now)
   ab_lock "rollback-$$" || ab_die "another A/B operation holds the lock"
   trap 'ab_unlock' EXIT
@@ -610,7 +610,7 @@ cmd_stage() {
   slot="$FLAG_SLOT"
   [ -n "$slot" ] || ab_die "usage: ab.sh stage --slot a|b [--port N] [--keep]"
   local dir; dir=$(ab_slot_dir "$slot")
-  [ -n "$dir" ] && [ -d "$dir/bin" ] || ab_die "slot $slot has no usable checkout ($dir)"
+  [ -n "$dir" ] && ab_slot_usable "$dir" || ab_die "slot $slot has no usable checkout ($dir)"
   port="$FLAG_PORT"
   [ -n "$port" ] || port=$(ab_config_get '.web.port // 3081')
   if lsof -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then

--- a/skills/dsh-snapshot-ab/scripts/lib/common.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/common.sh
@@ -37,10 +37,11 @@ ab_resolve_layout() {
     resolved=$(resolve_link "$launcher")
     root=$(CDPATH='' cd -- "$(dirname -- "$resolved")/.." 2>/dev/null && pwd || true)
   fi
-  if [ -z "${root:-}" ] || [ ! -d "${root:-}/bin" ]; then
-    # fallback: conventional home layout
+  if [ -z "${root:-}" ] || { [ ! -d "${root:-}/bin" ] && [ ! -f "${root:-}/apps/cli/src/bin.ts" ]; }; then
+    # fallback: conventional home layout (20260811+ dropped bin/dsh; the
+    # tsx source entry apps/cli/src/bin.ts is the bootable artifact)
     root="$HOME/.dsh/source/current"
-    [ -d "$root/bin" ] || ab_die "cannot resolve DSH source checkout (launcher '$launcher' -> '$root')"
+    { [ -d "$root/bin" ] || [ -f "$root/apps/cli/src/bin.ts" ]; } || ab_die "cannot resolve DSH source checkout (launcher '$launcher' -> '$root')"
     ab_warn "launcher resolution failed; fell back to $root"
   fi
   AB_CURRENT="$(CDPATH='' cd -- "$root" && pwd)"
@@ -152,6 +153,12 @@ ab_boot_cmd() {
   else
     printf 'env NODE_USE_ENV_PROXY=1 TSX_TSCONFIG_PATH=%s/tsconfig.json node --import %s/node_modules/tsx/dist/esm/index.mjs %s/apps/cli/src/bin.ts\n' "$dir" "$dir" "$dir"
   fi
+}
+
+# ab_slot_usable <dir> — true when the slot has a bootable CLI: bin/dsh
+# (0810-era) or the tsx source entry (20260811+ removed bin/dsh).
+ab_slot_usable() {
+  [ -x "$1/bin/dsh" ] || [ -f "$1/apps/cli/src/bin.ts" ]
 }
 
 # ---- misc -------------------------------------------------------------------


### PR DESCRIPTION
## 为什么

PR #8 修了启动命令，但漏了三类 `bin/` 存在性 gate：`switch` 的 `[ -d "$dir/bin" ]`（直接拦下本次 0811 切换：`candidate dir missing`）、`rollback`/`verify`/`stage` 的同类检查，以及 `ab_resolve_layout` 的 `[ -d "$root/bin" ]` ——后者在 0811 成为 current 后会让**每个 ab.sh 命令直接 ab_die**（0811 快照移除了 bin/dsh）。

## 改了什么

- `common.sh` 新增 **`ab_slot_usable <dir>`**（`bin/dsh` 存在 OR `apps/cli/src/bin.ts` 存在）。
- `ab_resolve_layout` 的布局校验改为接受任一产物（否则 current=0811 时布局解析必挂）。
- `ab.sh` 的 verify / switch / rollback / stage 四个 gate 全部改用 `ab_slot_usable`。

## 验收

- `bash -n` 三个脚本全过；`ab.sh status` 在 prepared 的 0811 槽上正常运行。
- 下一步 `ab.sh switch --yes` 可正常执行（本 PR 合并后重试）。
