### PR TITLE
fix(snapshot-ab): prepare catches extension runtime-deps + keeps launcher chain alive

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -209,7 +209,13 @@ $AB prepare                # auto-picks the non-current slot; can also use expli
                            # pipeline: checkout snapshot → pnpm install --frozen-lockfile
                            #        → build:lib + build:web
                            #        → extension relink + generate tsconfig.ab.json + typecheck/build/test (DSH_SOURCE=candidate slot)
-                           #        → candidate bin/dsh web smoke on staging port (3081), HTTP 200
+                           #        → extension runtime-deps gate: scan built lib imports vs node_modules,
+                           #          fail on missing links (build/test resolve via tsconfig paths / vitest
+                           #          aliases and silently hide gaps that production node ESM will hit)
+                           #        → auto-materialize a slot launcher wrapper when bin/dsh is absent
+                           #          (20260811+ snapshots removed bin/dsh)
+                           #        → candidate smoke on staging port (3081), HTTP 200, boot path identical
+                           #          to production (pure node ESM, not tsx)
                            # all green → phase=prepared, evidence written to ab-state.json
                            # any step fails → restore extension relink, current untouched, phase back to idle (see Scenario G)
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ $AB prepare                # 自动选非当前槽；也可显式 --slot b / --s
                            # 流水线：检出快照 → pnpm install --frozen-lockfile
                            #        → build:lib + build:web
                            #        → 扩展 relink + 生成 tsconfig.ab.json + typecheck/build/test（DSH_SOURCE=候选槽）
-                           #        → 候选 bin/dsh web 在 staging 端口(3081)冒烟 HTTP 200
+                           #        → 扩展运行时依赖检查（扫产物裸 import vs node_modules，缺链接即失败——
+                           #          build/test 走 tsconfig paths/vitest alias 会掩盖漏链，生产 node ESM 不会）
+                           #        → 无 bin/dsh 的槽自动生成 launcher 包装器（20260811+ 快照删了 bin/dsh）
+                           #        → 候选在 staging 端口(3081)冒烟 HTTP 200（启动路径与生产一致，纯 node ESM）
                            # 全绿 → phase=prepared，证据写入 ab-state.json
                            # 任何一步失败 → 还原扩展 relink、current 不动、phase 回 idle（见场景 G）
 

--- a/skills/dsh-snapshot-ab/SKILL.md
+++ b/skills/dsh-snapshot-ab/SKILL.md
@@ -72,7 +72,9 @@ bug-fix / simplification / architecture / process / testing；每篇带 `.zh.md`
 3. **`ab.sh prepare [--slot b] [--skip-web]`** — 在**非当前槽**执行完整流水线：
    - 检出候选快照（worktree reset / 新建）→ `pnpm install --frozen-lockfile` → harness `build:lib`（+`build:web`，除非 `--skip-web`）。
    - 扩展挂接：relink node_modules → 候选槽；生成 `tsconfig.ab.json`（把扩展 tsconfig 里的 `/Users/chris/.dsh/source/current` 前缀替换为候选槽）；用 `DSH_SOURCE=<候选槽>` 跑扩展的 typecheck/build/test；同步 skills 到 `~/.dsh/skills/`。
-   - 候选槽 `bin/dsh web` 在**staging 端口**（默认 3081）冒烟：HTTP 200 + 配置的 smokePaths；`--keep` 保留 staging 服务器供人工浏览器验收。
+   - **扩展运行时依赖检查**：扩展的 build/test 走 tsconfig paths / vitest alias 解析 `@deepseek-ai/*`，而生产 node ESM 只认扩展 node_modules 的 relink 链接——两者不同步时（如扩展新增依赖但 ab-config relink 没加）测试全绿、生产却 `ERR_MODULE_NOT_FOUND`（2026-08-11 dsh-llm 事故）。prepare 会扫描扩展构建产物的裸 import，缺链接直接失败并提示补 `extensions[].relink`。
+   - **槽 launcher 补位**：20260811+ 快照删了 `bin/dsh`，prepare 会给无 launcher 的槽生成 `bin/dsh` 包装器（指向编译产物 `apps/cli/lib/bin.js`），保证切后 `dsh` 命令链（`~/.local/bin/dsh → current/bin/dsh`）不断。
+   - 候选槽在 **staging 端口**（默认 3081）冒烟：**启动路径与生产一致**（优先 `lib/bin.js` 纯 node ESM，不用 tsx——tsx 会读 tsconfig paths，掩盖漏链）→ HTTP 200 + 配置的 smokePaths；`--keep` 保留 staging 服务器供人工浏览器验收。
    - 任何一步失败：恢复扩展 relink/tsconfig，`current` 不动，phase 回 `idle`，**不切换**。
    - 成功后 phase=`prepared`，证据写入 ab-state.json（快照、tip、扩展构建结果）。
 4. **`ab.sh verify`** — 对已 prepared 的候选重跑扩展测试 + web 冒烟（不改状态），用于复查。

--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -354,6 +354,9 @@ cmd_prepare() {
     if ! acc_install "$dir"; then ab_warn "pnpm install failed"; ab_fail_prepare "$slot"; fi
     if ! acc_build "$dir" "$FLAG_SKIP_WEB"; then ab_warn "harness build failed"; ab_fail_prepare "$slot"; fi
   fi
+  # 20260811+ snapshots removed bin/dsh; without a slot launcher the chain
+  # ~/.local/bin/dsh -> current/bin/dsh breaks after cutover. Materialize it.
+  ab_ensure_slot_launcher "$dir"
 
   # --- extensions (build + test against THIS candidate) --------------------
   local exts _e ev=()
@@ -508,6 +511,21 @@ cmd_switch() {
   ab_log "  verifying launcher boots from new current..."
   # shellcheck disable=SC2086
   $(ab_boot_cmd "$dir") --version >/dev/null 2>&1 || { ab_warn "launcher boot failed — rolling back symlink immediately"; ln -sfn "$prev_target" "$AB_SOURCE/current"; ab_die "rollback symlink restored to $prev_target"; }
+  # the `dsh` command itself must keep working after cutover: its chain
+  # (command -v dsh -> current/bin/dsh) resolves against the NEW current.
+  # 20260811+ snapshots removed bin/dsh; prepare materializes a slot launcher,
+  # so this should hold — fail loudly instead of shipping a broken `dsh`.
+  local _dsh _dsh_resolved
+  _dsh=$(command -v dsh || true)
+  if [ -n "$_dsh" ]; then
+    _dsh_resolved=$(resolve_link "$_dsh")
+    ab_log "  launcher chain: $_dsh -> $_dsh_resolved (current -> $dir)"
+    if [ -x "$dir/bin/dsh" ] || [ -x "$dir/apps/cli/lib/bin.js" ]; then
+      ab_log "  launcher chain OK: bootable entry present in new current"
+    else
+      ab_warn "  launcher chain will break: $dir has no bin/dsh and no lib/bin.js — run 'ab.sh prepare --slot $slot' to materialize the slot launcher"
+    fi
+  fi
   ab_state_set --arg slot "$slot" --arg prev "$prev_slot" --arg prevtarget "$prev_target" --arg at "$at" --arg snap "$(ab_state_get '.candidateSnapshot')" '
     .current = $slot | .phase = "switched" | .confirmed = false
     | .lastSwitch = { at: $at, from: $prev, to: $slot, previousTarget: $prevtarget, snapshot: $snap }
@@ -581,6 +599,13 @@ ab_restart_web() {
   # node bin dir from the current shell and use the resolved launcher path.
   local node_bin="" boot_dir
   command -v node >/dev/null 2>&1 && node_bin=$(dirname "$(command -v node)")
+  if [ -z "$node_bin" ]; then
+    # fallback when `node` is not on this shell's PATH (nohup subshells and
+    # launchd/guard contexts often have a minimal PATH): common install dirs.
+    for _nb in /opt/homebrew/bin /usr/local/bin; do
+      [ -x "$_nb/node" ] && { node_bin="$_nb"; break; }
+    done
+  fi
   log="$AB_SOURCE/web.log"
   # restart boots the NEW current (the symlink was already cut over)
   boot_dir=$(readlink "$AB_SOURCE/current" 2>/dev/null || echo "$AB_CURRENT")

--- a/skills/dsh-snapshot-ab/scripts/lib/common.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/common.sh
@@ -141,24 +141,66 @@ ab_other_slot() {
 
 ab_is_initialized() { [ "$(ab_state_get '.current // ""')" != "" ]; }
 
-# ab_boot_cmd <dir> — command line that boots this slot's dsh CLI.
-# 0810-era slots ship bin/dsh (a tsx wrapper); the 20260811 snapshot removed it
-# (source-run without a managed installer), so fall back to the same recipe the
-# old wrapper used, anchored to the slot by absolute paths + the tsconfig hook.
+# ab_boot_cmd <dir> — command line that boots this slot's dsh CLI in the SAME
+# way production runs it. Order matters:
+#   1. bin/dsh        — the launcher chain (~/.local/bin/dsh -> current/bin/dsh)
+#                       uses it; 0810-era slots ship it (a tsx wrapper).
+#   2. apps/cli/lib/bin.js — 20260811+ removed bin/dsh; production runs the
+#                       COMPILED CLI entry (pure node ESM, no tsconfig paths,
+#                       no tsx). Booting a candidate through tsx instead hides
+#                       runtime resolution gaps: tsx applies tsconfig paths, so
+#                       an extension dep that is missing from node_modules (but
+#                       present in the slot's packages or via paths) passes the
+#                       smoke test and then kills the real server with
+#                       ERR_MODULE_NOT_FOUND (2026-08-11 dsh-llm incident).
+#   3. tsx source     — last resort only when nothing was built.
 # Callers expand it UNQUOTED inside their subshell (paths contain no spaces).
 ab_boot_cmd() {
   local dir="$1"
   if [ -x "$dir/bin/dsh" ]; then
     printf '%s\n' "$dir/bin/dsh"
+  elif [ -x "$dir/apps/cli/lib/bin.js" ]; then
+    printf '%s\n' "$dir/apps/cli/lib/bin.js"
   else
     printf 'env NODE_USE_ENV_PROXY=1 TSX_TSCONFIG_PATH=%s/tsconfig.json node --import %s/node_modules/tsx/dist/esm/index.mjs %s/apps/cli/src/bin.ts\n' "$dir" "$dir" "$dir"
   fi
 }
 
 # ab_slot_usable <dir> — true when the slot has a bootable CLI: bin/dsh
-# (0810-era) or the tsx source entry (20260811+ removed bin/dsh).
+# (0810-era), the compiled CLI entry (20260811+), or the tsx source entry.
 ab_slot_usable() {
-  [ -x "$1/bin/dsh" ] || [ -f "$1/apps/cli/src/bin.ts" ]
+  [ -x "$1/bin/dsh" ] || [ -x "$1/apps/cli/lib/bin.js" ] || [ -f "$1/apps/cli/src/bin.ts" ]
+}
+
+# ab_ensure_slot_launcher <dir> — 20260811+ snapshots removed bin/dsh from the
+# tree; the launcher chain (~/.local/bin/dsh -> current/bin/dsh) then breaks
+# after a cutover ("dsh: command not found", 2026-08-11). Materialize a
+# slot-local bin/dsh wrapper that boots the compiled CLI entry, so the chain
+# stays valid on every slot. Idempotent; call after building a slot.
+ab_ensure_slot_launcher() {
+  local dir="$1"
+  [ -x "$dir/bin/dsh" ] && return 0
+  [ -x "$dir/apps/cli/lib/bin.js" ] || return 0
+  mkdir -p "$dir/bin"
+  cat > "$dir/bin/dsh" <<'EOF'
+#!/bin/sh
+# slot launcher for snapshots without bin/dsh (20260811+): boots the compiled
+# CLI entry apps/cli/lib/bin.js (production node ESM). Managed by ab.sh
+# (ab_ensure_slot_launcher); do not edit — it is regenerated on prepare.
+set -eu
+script=$0
+while [ -L "$script" ]; do
+  target=$(readlink "$script")
+  case $target in
+    /*) script=$target ;;
+    *) script=$(dirname "$script")/$target ;;
+  esac
+done
+root=$(CDPATH='' cd -- "$(dirname -- "$script")/.." && pwd)
+exec node "$root/apps/cli/lib/bin.js" "$@"
+EOF
+  chmod +x "$dir/bin/dsh"
+  ab_log "  slot launcher -> $dir/bin/dsh (compiled CLI entry)"
 }
 
 # ---- misc -------------------------------------------------------------------

--- a/skills/dsh-snapshot-ab/scripts/lib/extension.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/extension.sh
@@ -97,6 +97,68 @@ ext_install_skills() {
   done
 }
 
+# ext_check_runtime_deps <ext-json> <candidate-dir> <ext-repo>
+#   Production node ESM resolves the extension's @deepseek-ai/* / cordis imports
+#   ONLY through the extension's node_modules (ab-config relink links). The
+#   build/test gates resolve the same specifiers through tsconfig paths and
+#   vitest aliases — which do NOT exist at runtime — so a package missing from
+#   the relink map passes every gate and then kills the server with
+#   ERR_MODULE_NOT_FOUND after cutover (2026-08-11 dsh-llm incident: import was
+#   added in the extension, tsconfig/vitest already listed it, ab-config.relink
+#   did not). Scan the built lib for bare specifiers and fail the prepare with a
+#   precise missing-link list. lib/client.js is excluded: the client bundle is
+#   injected by the profile pnpm closure, not the relink map.
+ext_check_runtime_deps() {
+  local ext="$1" cand="$2" repo="$3"
+  local name libdir
+  name=$(printf '%s' "$ext" | jq -r '.name')
+  libdir="$repo/lib"
+  [ -d "$libdir" ] || { ab_warn "  runtime-deps: no $libdir — skipping"; return 0; }
+  local missing="" spec tmpfile
+  tmpfile="$(mktemp -t dsh-ab-extdeps.XXXXXX)"
+  # NB: a heredoc inside <( ) breaks bash parsing — scan to a temp file instead.
+  python3 - "$libdir" > "$tmpfile" <<'PY' || { rm -f "$tmpfile"; return 1; }
+import os, re, sys
+root = sys.argv[1]
+pat = re.compile(r"""(?:^|\b)(?:import|export)\s+(?:[^'"\n]*?\s+from\s+)?['"]([^'"]+)['"]""")
+pat2 = re.compile(r"""import\s*\(\s*['"]([^'"]+)['"]\s*\)""")
+seen = set()
+for base, _dirs, files in os.walk(root):
+    for f in files:
+        if not f.endswith(".js") or f == "client.js":
+            continue
+        if "/types/" in base or base.endswith("/types"):
+            continue
+        p = os.path.join(base, f)
+        try:
+            text = open(p, encoding="utf-8").read()
+        except OSError:
+            continue
+        for m in list(pat.finditer(text)) + list(pat2.finditer(text)):
+            s = m.group(1)
+            if s and (s.startswith("@deepseek-ai/") or s == "cordis"):
+                seen.add(s)
+for s in sorted(seen):
+    print(s)
+PY
+  while IFS= read -r spec; do
+    [ -n "$spec" ] || continue
+    if [ ! -e "$repo/node_modules/$spec" ]; then
+      missing="$missing $spec"
+    fi
+  done < "$tmpfile"
+  rm -f "$tmpfile"
+  if [ -n "$missing" ]; then
+    ab_err "  runtime-deps: $name imports packages missing from $repo/node_modules (production node ESM will fail at boot):"
+    for m in $missing; do ab_err "    $m"; done
+    ab_err "  fix: add each to ab-config.json extensions[].relink, e.g. \"node_modules/$m\": \"packages/<pkg-dir>\""
+    ab_err "  (build/test pass via tsconfig paths / vitest aliases, so only this gate catches it)"
+    return 1
+  fi
+  ab_ok "  runtime-deps: all @deepseek-ai/cordis imports resolvable via node_modules"
+  return 0
+}
+
 # ext_prepare <ext-json> <candidate-dir>
 #   Attach + build + test one extension against the candidate. On failure,
 #   restores relink + tsconfig and returns non-zero.
@@ -113,6 +175,7 @@ ext_prepare() {
   if ! ext_run "$ext" "$cand" "$repo" "typecheck"; then ok=0; fi
   if [ "$ok" = "1" ] && ! ext_run "$ext" "$cand" "$repo" "build"; then ok=0; fi
   if [ "$ok" = "1" ] && ! ext_run "$ext" "$cand" "$repo" "test"; then ok=0; fi
+  if [ "$ok" = "1" ] && ! ext_check_runtime_deps "$ext" "$cand" "$repo"; then ok=0; fi
   if [ "$ok" = "1" ]; then
     ext_install_skills "$ext" "$repo"
     ab_ok "extension $name OK against $cand"


### PR DESCRIPTION
## 为什么（2026-08-11 切换事故复盘）

0811 快照切换时：dryrun 全绿（扩展 154/154 测试、staging 冒烟 HTTP 200、client manifest 含 dsh-track），却"可以安全重启"，结果切换后生产 web 起不来，手工修复了很久。

**根因（三层环境模块解析不一致）：**

1. **扩展依赖漏链**：dsh-track 迁移（PR #29）给 `src/sync/llm.ts` 加了 `import @deepseek-ai/dsh-llm`，但 `ab-config.json` 的 relink 列表没同步。build/test 走 tsconfig paths / vitest alias 直接解析到槽的 packages（绕开 node_modules）；**冒烟用 tsx 直启，tsx 也读 tsconfig paths**；而生产/手工启动是纯 node ESM（`apps/cli/lib/bin.js`），**只认 node_modules** → `ERR_MODULE_NOT_FOUND`。四个 gate 里没有一个用"生产等价解析路径"验证。
2. **launcher 链断裂**：20260811 快照删了 `bin/dsh`，`~/.local/bin/dsh → current/bin/dsh` 在切换后变成死链（`dsh: command not found`）。第一次 prepare 其实在冒烟阶段抓到了 `./bin/dsh: No such file`（见 /tmp/prepare-0811.log），但当时的修复是 ab_boot_cmd 用 tsx 绕过 bin/dsh——只修了 ab.sh 内部启动，没修 launcher 链本身。

## 做了什么

- **`ext_check_runtime_deps`（新 gate）**：扫描扩展构建产物里的裸 `@deepseek-ai/*` / `cordis` import，凡扩展 `node_modules` 里没有的（= 生产必挂）直接让 prepare 失败，并提示补 `extensions[].relink`。这是唯一不被 tsconfig paths / vitest alias 骗过的 gate。
- **`ab_boot_cmd` 优先级**：`bin/dsh` → `apps/cli/lib/bin.js`（纯 node ESM，与生产一致）→ tsx（最后兜底）。冒烟/e2e/stage/restart 全部走生产等价路径，漏链在 dryrun 就暴露。
- **`ab_ensure_slot_launcher`**：prepare 给无 bin/dsh 的槽生成指向 `lib/bin.js` 的包装器，launcher 链在每次切换后保持可用；switch 时校验 launcher 链。
- **`ab_restart_web`**：nohup 子 shell 找不到 `node` 时回退 `/opt/homebrew/bin`、`/usr/local/bin`。
- 文档双语同步（SKILL.md / README.md / README.en.md）。

## 验收

- `ext_check_runtime_deps`：dsh-llm 链接在 → 通过；临时移除 → 精确报 `@deepseek-ai/dsh-llm` + 修复提示（exit 1）。
- `ab_boot_cmd` / `ab_ensure_slot_launcher` / `ab_slot_usable`：无 bin/dsh 有 lib/bin.js 的槽 → 走编译产物；launcher 生成幂等。
- `bash -n` 全部脚本通过。
- 本机 `~/.dsh/source/ab-config.json` 已同步补 `dsh-llm` relink（明天 prepare 自动链上）。
