### PR TITLE
fix(snapshot-ab): confirm = production acceptance gate + ship 0811 switch post-mortem

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -209,7 +209,13 @@ $AB prepare                # auto-picks the non-current slot; can also use expli
                            # pipeline: checkout snapshot → pnpm install --frozen-lockfile
                            #        → build:lib + build:web
                            #        → extension relink + generate tsconfig.ab.json + typecheck/build/test (DSH_SOURCE=candidate slot)
-                           #        → candidate bin/dsh web smoke on staging port (3081), HTTP 200
+                           #        → extension runtime-deps gate: scan built lib imports vs node_modules,
+                           #          fail on missing links (build/test resolve via tsconfig paths / vitest
+                           #          aliases and silently hide gaps that production node ESM will hit)
+                           #        → auto-materialize a slot launcher wrapper when bin/dsh is absent
+                           #          (20260811+ snapshots removed bin/dsh)
+                           #        → candidate smoke on staging port (3081), HTTP 200, boot path identical
+                           #          to production (pure node ESM, not tsx)
                            # all green → phase=prepared, evidence written to ab-state.json
                            # any step fails → restore extension relink, current untouched, phase back to idle (see Scenario G)
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ $AB prepare                # 自动选非当前槽；也可显式 --slot b / --s
                            # 流水线：检出快照 → pnpm install --frozen-lockfile
                            #        → build:lib + build:web
                            #        → 扩展 relink + 生成 tsconfig.ab.json + typecheck/build/test（DSH_SOURCE=候选槽）
-                           #        → 候选 bin/dsh web 在 staging 端口(3081)冒烟 HTTP 200
+                           #        → 扩展运行时依赖检查（扫产物裸 import vs node_modules，缺链接即失败——
+                           #          build/test 走 tsconfig paths/vitest alias 会掩盖漏链，生产 node ESM 不会）
+                           #        → 无 bin/dsh 的槽自动生成 launcher 包装器（20260811+ 快照删了 bin/dsh）
+                           #        → 候选在 staging 端口(3081)冒烟 HTTP 200（启动路径与生产一致，纯 node ESM）
                            # 全绿 → phase=prepared，证据写入 ab-state.json
                            # 任何一步失败 → 还原扩展 relink、current 不动、phase 回 idle（见场景 G）
 

--- a/skills/dsh-snapshot-ab/SKILL.md
+++ b/skills/dsh-snapshot-ab/SKILL.md
@@ -90,8 +90,12 @@ bug-fix / simplification / architecture / process / testing；每篇带 `.zh.md`
    - 先写 handoff 说明（`dsh web` 重启会终止当前 agent 会话本身）。
    - **`ab.sh switch`**（manual 模式需 `--yes`；auto 模式需 e2e 已过）— 原子 `ln -sfn current -> 候选槽` → 验证 launcher 可启动 → 重启 web（自动杀旧 PID、nohup 启动、轮询 HTTP 200）→ phase=`switched`、confirmed=`false`。旧槽原样保留 = 回滚点。
    - **装了 `dsh-web-guard` 时**：ab.sh 杀 web 后守护会自动用完整环境拉起新 current（更可靠的兜底）；ab.sh 自己先启动成功则守护不抢。无论谁拉起，**切换后浏览器必须硬刷新（Cmd+Shift+R）**——旧 tab 里是切换前加载的 boot manifest，新 client 插件/面板（如 dsh-track 的 ◆）只在刷新后的页面出现（2026-08-11 实测坑）。
-8. **确认稳定**：用户确认新版本可用后 **`ab.sh confirm`**（confirmed=true）。在此之前 `prepare` 拒绝回收回滚槽（除非 `--force`）。
+8. **确认稳定 = 生产验收**：**`ab.sh confirm`** 内置生产验收 gate（2026-08-11 事故后新增）——生产端口 HTTP 200、运行 web 进程来自当前槽、`dsh` launcher 链解析进当前槽、扩展 client manifest 在页面上，四项全过才写 `confirmed=true`（confirmed=true 后 `prepare` 才允许回收回滚槽）。**任何一项不过即拒绝确认**——"确认"不再是口头背书，而是对生产等价路径的实测。
 9. 下一天：A/B 角色互换，`prepare` 自动选非当前槽。
+
+> 事故复盘：2026-08-11 切换事故（dryrun 全绿但生产起不来）的完整根因链与防复发措施见
+> [`references/postmortem-ab-switch-20260811.md`](references/postmortem-ab-switch-20260811.md)（中）/ 
+> [`references/postmortem-ab-switch-20260811.en.md`](references/postmortem-ab-switch-20260811.en.md)（英）。
 
 ## 回滚
 

--- a/skills/dsh-snapshot-ab/SKILL.md
+++ b/skills/dsh-snapshot-ab/SKILL.md
@@ -72,7 +72,9 @@ bug-fix / simplification / architecture / process / testing；每篇带 `.zh.md`
 3. **`ab.sh prepare [--slot b] [--skip-web]`** — 在**非当前槽**执行完整流水线：
    - 检出候选快照（worktree reset / 新建）→ `pnpm install --frozen-lockfile` → harness `build:lib`（+`build:web`，除非 `--skip-web`）。
    - 扩展挂接：relink node_modules → 候选槽；生成 `tsconfig.ab.json`（把扩展 tsconfig 里的 `/Users/chris/.dsh/source/current` 前缀替换为候选槽）；用 `DSH_SOURCE=<候选槽>` 跑扩展的 typecheck/build/test；同步 skills 到 `~/.dsh/skills/`。
-   - 候选槽 `bin/dsh web` 在**staging 端口**（默认 3081）冒烟：HTTP 200 + 配置的 smokePaths；`--keep` 保留 staging 服务器供人工浏览器验收。
+   - **扩展运行时依赖检查**：扩展的 build/test 走 tsconfig paths / vitest alias 解析 `@deepseek-ai/*`，而生产 node ESM 只认扩展 node_modules 的 relink 链接——两者不同步时（如扩展新增依赖但 ab-config relink 没加）测试全绿、生产却 `ERR_MODULE_NOT_FOUND`（2026-08-11 dsh-llm 事故）。prepare 会扫描扩展构建产物的裸 import，缺链接直接失败并提示补 `extensions[].relink`。
+   - **槽 launcher 补位**：20260811+ 快照删了 `bin/dsh`，prepare 会给无 launcher 的槽生成 `bin/dsh` 包装器（指向编译产物 `apps/cli/lib/bin.js`），保证切后 `dsh` 命令链（`~/.local/bin/dsh → current/bin/dsh`）不断。
+   - 候选槽在 **staging 端口**（默认 3081）冒烟：**启动路径与生产一致**（优先 `lib/bin.js` 纯 node ESM，不用 tsx——tsx 会读 tsconfig paths，掩盖漏链）→ HTTP 200 + 配置的 smokePaths；`--keep` 保留 staging 服务器供人工浏览器验收。
    - 任何一步失败：恢复扩展 relink/tsconfig，`current` 不动，phase 回 `idle`，**不切换**。
    - 成功后 phase=`prepared`，证据写入 ab-state.json（快照、tip、扩展构建结果）。
 4. **`ab.sh verify`** — 对已 prepared 的候选重跑扩展测试 + web 冒烟（不改状态），用于复查。

--- a/skills/dsh-snapshot-ab/references/postmortem-ab-switch-20260811.en.md
+++ b/skills/dsh-snapshot-ab/references/postmortem-ab-switch-20260811.en.md
@@ -1,0 +1,99 @@
+# Post-mortem: A/B snapshot switch incident (2026-08-11 → 08-12)
+
+> Incident: the 20260811 snapshot A/B cutover passed every dry-run gate and was
+> declared "safe to restart", yet the production web could not boot after the
+> switch. Recovery required manual fixes (a bin/dsh wrapper plus a manual
+> dsh-llm relink). ~9 minutes of downtime on port 3080.
+> 中文版：[postmortem-ab-switch-20260811.md](postmortem-ab-switch-20260811.md)
+
+---
+
+## 1. Timeline (local time PDT)
+
+| Time | Event |
+|---|---|
+| 15:57:42 | dsh-track migration PR #29 merged — `src/sync/llm.ts` gains `import @deepseek-ai/dsh-llm`; **ab-config relink NOT updated** |
+| 15:55–16:00 | First `ab.sh prepare` (old ab.sh) → **smoke failed**: `nohup: ./bin/dsh: No such file or directory` (the 0811 snapshot removed bin/dsh) |
+| 16:00–16:04 | Agent patches ab.sh: PR #8 `ab_boot_cmd` (tsx source boot when bin/dsh is missing) → second prepare all green: 154/154 extension tests, **smoke HTTP 200 (2s)**, client manifest contains dsh-track → phase=prepared |
+| 17:47:18 | User approves: "switch" → handoff → 17:47:54 first switch blocked by the `[ -d "$dir/bin" ]` gate |
+| 17:48–17:49 | Gate fix (PR #9) → sync ab.sh → 17:49:54 switch retry → **cutover succeeds (current→slot-a)** → web restart fails (`nohup: dsh` / `exec: node: not found`, 11 attempts) → session killed |
+| 17:52–17:58 | Post-recovery diagnosis: launcher chain broken (`dsh: command not found`) → manual slot-a/bin/dsh wrapper → `dsh web` reports **`ERR_MODULE_NOT_FOUND: @deepseek-ai/dsh-llm`** → manual `ln -sfn` |
+| 17:59:00 | `dsh web` up (pure node `apps/cli/lib/bin.js`), HTTP 200, dsh-track mounted |
+
+---
+
+## 2. Why the dry run was all green yet production failed — root-cause chain
+
+### Root cause 1 (core): module resolution differs across environments — only production is honest
+
+The same `import @deepseek-ai/dsh-llm` is "caught" by a different mechanism at every stage:
+
+| Stage | Resolution mechanism | dsh-llm result |
+|---|---|---|
+| Extension typecheck/build | tsconfig.json `paths` (dsh-llm → slot packages) | ✅ passes |
+| Extension tests (vitest 154/154) | vitest.config.ts `resolve.alias` (dsh-llm → slot packages) | ✅ passes |
+| **Web smoke (staging 3081)** | **ab_boot_cmd = tsx boot; tsx reads `TSX_TSCONFIG_PATH` tsconfig paths** (`resolveTsPaths` applies to non-node_modules parents) | ✅ HTTP 200 |
+| **Production / manual start** | **pure node ESM (`apps/cli/lib/bin.js`) → node_modules only** | ❌ `ERR_MODULE_NOT_FOUND` |
+
+- The first three environments all resolve **around** node_modules (equivalent to a "link exists" illusion);
+- Only production actually checks `dsh-involute/node_modules/@deepseek-ai/dsh-llm`, which the ab-config relink map never listed → boot fails.
+- **No prepare step validated extension deps through the production-equivalent resolution path.** The smoke tested the tsx path, not the node-ESM path.
+
+> **One-line root cause**: build/test/smoke module resolution (paths/alias) and production module resolution
+> (node_modules symlinks) are two separate worlds; their "package manifests" (tsconfig/vitest paths vs
+> ab-config relink) are maintained by hand and out of sync. When an extension adds a dependency, only the
+> former gets updated — and the one gate that could pierce the illusion (production-equivalent smoke) did not exist.
+
+### Root cause 2: the launcher chain was outside every gate, masked by a "workaround-style" fix
+
+- `~/.local/bin/dsh → ~/.dsh/source/current/bin/dsh` is a fixed symlink; the 0811 snapshot removed `bin/dsh`, so after cutover current→slot-a had no bin/dsh → **the `dsh` command silently disappeared**.
+- The first prepare's smoke **did** catch `./bin/dsh: No such file` — but the fix direction was `ab_boot_cmd` tsx *bypass* (enough for ab.sh's internal start), **not a fix of the launcher chain itself**. Result: ab.sh's own boot survived, while the user/guard `dsh` command stayed broken.
+- The switch gate verified `$(ab_boot_cmd) --version` (tsx path), not `dsh --version` (launcher-chain path) → the broken chain passed unnoticed.
+
+### Root cause 3: the restart environment had no node/dsh on PATH
+
+- The 17:49:54 restart failed at the nohup layer: `nohup: dsh: No such file or directory` / `exec: node: not found`.
+- ab.sh restart's nohup subshell PATH lacked the node install dir → even without the dependency issue the web could not start.
+- (A third, independent trap: the restart PATH assumed a login shell's PATH.)
+
+### Root cause 4 (process): the verification power of the gate list was never examined
+
+"Safe to restart" = all gates green (154/154 + smoke 200 + manifest). But per gate:
+
+| Gate | Verified | NOT verified |
+|---|---|---|
+| Extension typecheck/build | types/syntax, artifacts | runtime deps availability in node_modules (paths masks it) |
+| Extension tests 154/154 | logic correctness | module resolution parity with production (alias masks it) |
+| Smoke HTTP 200 + manifest | tsx boot path works, client row present | **pure node ESM boot**, launcher chain, node_modules dep completeness |
+| Switch launcher check | `ab_boot_cmd --version` (tsx) | `dsh` (launcher chain) |
+
+**Lesson**: "all green" only means the covered dimensions are green. **No gate covered the "production-equivalent boot path" dimension — the only dimension that matters after cutover.**
+
+---
+
+## 3. Prevention fixes (shipped)
+
+**Mechanism fixes (dsh-harness-ops):**
+
+1. **`ext_check_runtime_deps` (new gate, PR #10)**: prepare scans the extension's built lib for bare `@deepseek-ai/*` / `cordis` imports and fails prepare when any is missing from the extension's node_modules, with a hint to add `extensions[].relink`. The only gate that tsconfig paths / vitest aliases cannot fool.
+2. **`ab_boot_cmd` production-path priority (PR #10)**: `bin/dsh` → `apps/cli/lib/bin.js` (pure node ESM) → tsx (last resort). Smoke/e2e/stage/restart all use the production path, so missing links surface at smoke time.
+3. **`ab_ensure_slot_launcher` (PR #10)**: prepare materializes a `bin/dsh` wrapper (pointing at `lib/bin.js`) for slots without one; the launcher chain stays valid after every cutover; switch verifies it.
+4. **`ab_restart_web` (PR #10)**: falls back to `/opt/homebrew/bin`, `/usr/local/bin` when node is not on the nohup PATH.
+5. **`ab.sh confirm` = production acceptance gate (this change)**: confirm now requires four production checks — production port HTTP 200, running web process from the current slot, `dsh` launcher chain resolving inside the current slot, and extension client ids present in the production boot manifest. Any failure refuses the confirm.
+6. **`ab_detect_web` / restart process matching (this change)**: matches both launch styles — tsx source and compiled CLI.
+
+**Local config:**
+7. `~/.dsh/source/ab-config.json` relink gained `"node_modules/@deepseek-ai/dsh-llm": "packages/llm/llm"`.
+
+**Verified (live):**
+- `ext_check_runtime_deps`: link present → pass; temporarily removed → reports exactly `@deepseek-ai/dsh-llm` (exit 1).
+- Slot without bin/dsh (with lib/bin.js) → `ab_boot_cmd` uses the compiled entry; `ab_ensure_slot_launcher` is idempotent.
+- `ab.sh confirm` refused when the process argv used the `current` symlink form, then passed all four checks after the matcher was fixed, and only then wrote confirmed=true.
+
+---
+
+## 4. Three rules for the future
+
+1. **Acceptance must run the production-equivalent path**: smoke/boot gates must use the same resolution environment as production (pure node ESM + node_modules). More lenient paths (tsx/tsconfig paths) may only be fallbacks, never the only gate. **Confirmation (confirm) must likewise be based on production acceptance.**
+2. **The three dependency manifests must stay in sync**: when an extension adds an `@deepseek-ai/*` dependency, update tsconfig paths, vitest alias, and ab-config relink **together**. `ext_check_runtime_deps` blocks the prepare if relink is missed.
+3. **A workaround is not a fix**: any "this path fails, so use another path" fix must also verify the original path (e.g. the launcher chain `dsh --version`) still works for users/guards.

--- a/skills/dsh-snapshot-ab/references/postmortem-ab-switch-20260811.md
+++ b/skills/dsh-snapshot-ab/references/postmortem-ab-switch-20260811.md
@@ -1,0 +1,96 @@
+# AB 切换事故复盘（2026-08-11 → 08-12）
+
+> 事故：0811 快照 A/B 切换，dryrun 全绿且结论"可以安全重启"，切换后生产 web 起不来，
+> 手工修复（bin/dsh 包装器 + dsh-llm 手工 relink）后才恢复。3080 停机约 9 分钟。
+> English version: [postmortem-ab-switch-20260811.en.md](postmortem-ab-switch-20260811.en.md)
+
+---
+
+## 一、事故时间线（本地时间 PDT）
+
+| 时间 | 事件 |
+|---|---|
+| 15:57:42 | dsh-track 迁移 PR #29 合并 —— `src/sync/llm.ts` 新增 `import @deepseek-ai/dsh-llm`；**ab-config relink 未同步** |
+| 15:55–16:00 | 第一次 `ab.sh prepare`（旧版 ab.sh）→ **冒烟失败**：`nohup: ./bin/dsh: No such file or directory`（0811 快照删了 bin/dsh） |
+| 16:00–16:04 | agent 修 ab.sh：PR #8 `ab_boot_cmd`（bin/dsh 缺失时 **tsx 直启**）→ 第二次 prepare 全绿：扩展 154/154、**冒烟 HTTP 200（2s）**、client manifest 含 dsh-track → phase=prepared |
+| 17:47:18 | 用户批准："switch" → handoff → 17:47:54 第一次 switch 被 gate 拦下（`[ -d "$dir/bin" ]`） |
+| 17:48–17:49 | 修 gate（PR #9）→ 同步 ab.sh → 17:49:54 重试 switch → **cutover 成功（current→slot-a）** → 重启 web 失败（`nohup: dsh` / `exec: node: not found`，11 次）→ 会话被杀 |
+| 17:52–17:58 | 恢复后诊断：launcher 链断（`dsh: command not found`）→ 手工建 slot-a/bin/dsh 包装器 → `dsh web` 报 **`ERR_MODULE_NOT_FOUND: @deepseek-ai/dsh-llm`** → 手工 `ln -sfn` 补链接 |
+| 17:59:00 | `dsh web` 起来（纯 node `apps/cli/lib/bin.js`），HTTP 200，dsh-track 挂载 |
+
+---
+
+## 二、为什么 dryrun 全绿、却说"可以安全重启"——根因链
+
+### 根因 1（核心）：四个环境对 `@deepseek-ai/*` 的解析机制不一致，只有生产"诚实"
+
+同一段 `import @deepseek-ai/dsh-llm`，在验收链的每一环都被不同机制"接住"：
+
+| 环节 | 解析机制 | dsh-llm 结果 |
+|---|---|---|
+| 扩展 typecheck/build | tsconfig.json `paths`（含 dsh-llm → 槽的 packages） | ✅ 通过 |
+| 扩展测试（vitest 154/154） | vitest.config.ts `resolve.alias`（含 dsh-llm → 槽的 packages） | ✅ 通过 |
+| **web 冒烟（staging 3081）** | **ab_boot_cmd = tsx 直启，tsx 读 `TSX_TSCONFIG_PATH` 的 tsconfig paths**（`resolveTsPaths` 对非 node_modules 父模块生效） | ✅ HTTP 200 |
+| **生产 / 手工启动** | **纯 node ESM（`apps/cli/lib/bin.js`）→ 只查 node_modules** | ❌ `ERR_MODULE_NOT_FOUND` |
+
+- 前三个环境全部**绕开 node_modules** 解析成功（等价于"链接存在"的幻觉）；
+- 只有生产环境老老实实查 `dsh-involute/node_modules/@deepseek-ai/dsh-llm`，而 ab-config relink 列表里没有它 → 挂。
+- **prepare 没有任何一步用"生产等价解析路径"验证扩展依赖**。冒烟验证的是 tsx 路径，不是 node ESM 路径。
+
+> **一句话根因**：`build/test/冒烟` 的模块解析（paths/alias）与 `生产运行` 的模块解析（node_modules symlink）是两套世界，
+> 两套世界的"包清单"（tsconfig/vitest paths vs ab-config relink）各自手维护、不同步；
+> 扩展新增依赖时只更新了前者，漏了后者，而唯一能戳破幻象的 gate（生产等价路径冒烟）不存在。
+
+### 根因 2：launcher 链不在任何 gate 覆盖内，且被"绕过式修复"掩盖
+
+- `~/.local/bin/dsh → ~/.dsh/source/current/bin/dsh` 是固定 symlink；0811 快照删了 `bin/dsh` → 切换后 current→slot-a 无 bin/dsh → **`dsh` 命令直接消失**。
+- 第一次 prepare 的冒烟**其实抓到了** `./bin/dsh: No such file`——但当时修复方向是 `ab_boot_cmd` 用 tsx **绕过** bin/dsh（ab.sh 内部能启动即可），**没有修复 launcher 链本身**。结果：ab.sh 自己的启动活了，用户/guard 的 `dsh` 命令仍然断。
+- switch 的 gate 验证的是 `$(ab_boot_cmd) --version`（tsx 路径），不是 `dsh --version`（launcher 链路径）→ 断链无感通过。
+
+### 根因 3：restart 环境的 PATH 无 node/dsh
+
+- 17:49:54 重启失败在 nohup 层面：`nohup: dsh: No such file or directory` / `exec: node: not found`。
+- ab.sh restart 的 nohup 子 shell PATH 未含 node 安装目录 → 即使依赖问题不存在，web 也起不来。
+- （独立于根因 1/2 的第三个坑：重启环境的 PATH 假设了登录 shell 的 PATH。）
+
+### 根因 4（流程）：验收 gate 清单的"验证力"没有被审视
+
+"可以安全重启"的结论 = gate 全绿（154/154 + 冒烟 200 + manifest）。但回看每个 gate 的实际覆盖：
+
+| gate | 验证了什么 | 没验证什么 |
+|---|---|---|
+| 扩展 typecheck/build | 类型/语法、产物生成 | 运行时依赖在 node_modules 的可用性（paths 兜底） |
+| 扩展测试 154/154 | 逻辑正确性 | 模块解析与生产一致（alias 兜底） |
+| 冒烟 HTTP 200 + manifest | tsx 启动路径能起、client 行在 | **纯 node ESM 启动**、launcher 链、node_modules 依赖完整性 |
+| switch launcher 验证 | `ab_boot_cmd --version`（tsx） | `dsh`（launcher 链） |
+
+**教训**：验收"全绿"只说明 gate 覆盖的维度绿。**gate 没有验证"生产等价启动路径"这个维度，而这个维度恰好是切换后唯一重要的维度。**
+
+---
+
+## 三、防复发修复（已落地）
+
+**机制修复（dsh-harness-ops）：**
+
+1. **`ext_check_runtime_deps`（新 gate，PR #10）**：prepare 扫描扩展构建产物里的裸 `@deepseek-ai/*` / `cordis` import，凡扩展 `node_modules` 缺失的**直接 prepare 失败**并提示补 `extensions[].relink`。唯一不被 tsconfig paths / vitest alias 骗过的 gate。
+2. **`ab_boot_cmd` 优先级改为生产等价路径（PR #10）**：`bin/dsh` → `apps/cli/lib/bin.js`（纯 node ESM）→ tsx（仅兜底）。冒烟/e2e/stage/restart 全部走生产路径 → 漏链在冒烟即挂。
+3. **`ab_ensure_slot_launcher`（PR #10）**：prepare 给无 bin/dsh 的槽自动生成 `bin/dsh` 包装器（指向 `lib/bin.js`）→ launcher 链切换后保持可用；switch 时校验。
+4. **`ab_restart_web`（PR #10）**：nohup 环境 node 不在 PATH 时回退 `/opt/homebrew/bin`、`/usr/local/bin`。
+5. **`ab.sh confirm` = 生产验收 gate（本次）**：确认前必须通过四项生产验收——生产端口 HTTP 200、运行进程来自当前槽、`dsh` launcher 链解析进当前槽、扩展 client manifest 在页面上。任一不过 → 拒绝确认。
+6. **`ab_detect_web` / restart 进程匹配（本次）**：同时匹配 tsx 源码启动与编译产物启动两种进程形态。
+
+**本机配置：**
+7. `~/.dsh/source/ab-config.json` relink 补 `"node_modules/@deepseek-ai/dsh-llm": "packages/llm/llm"`。
+
+**验证（实测）：**
+- `ext_check_runtime_deps`：链接在 → 通过；临时移除 → 精确报 `@deepseek-ai/dsh-llm`（exit 1）。
+- 无 bin/dsh 槽（有 lib/bin.js）→ `ab_boot_cmd` 走编译产物；`ab_ensure_slot_launcher` 幂等。
+- `ab.sh confirm` 在"进程 argv 用 current 符号路径"的误报修正后，四项验收全绿才写入 confirmed=true。
+
+---
+
+## 四、给未来的三条铁律
+
+1. **验收必须走生产等价路径**：冒烟/启动类 gate 一律用与生产相同的解析环境（纯 node ESM + node_modules），禁止用 tsx/tsconfig paths 这类"更宽容"的路径做唯一验证——宽容的路径只能作为兜底，不能作为 gate。**确认（confirm）同样必须基于生产验收。**
+2. **依赖清单三处必须一致**：扩展新增 `@deepseek-ai/*` 依赖时，tsconfig paths、vitest alias、ab-config relink **三处同改**。`ext_check_runtime_deps` 会在漏改 relink 时拦下 prepare。
+3. **"绕过"不是修复**：任何"某条路径起不来就换条路径"的修复，必须同时检查那条路径本身（如 launcher 链 `dsh --version`）是否对用户/guard 可用。

--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -354,6 +354,9 @@ cmd_prepare() {
     if ! acc_install "$dir"; then ab_warn "pnpm install failed"; ab_fail_prepare "$slot"; fi
     if ! acc_build "$dir" "$FLAG_SKIP_WEB"; then ab_warn "harness build failed"; ab_fail_prepare "$slot"; fi
   fi
+  # 20260811+ snapshots removed bin/dsh; without a slot launcher the chain
+  # ~/.local/bin/dsh -> current/bin/dsh breaks after cutover. Materialize it.
+  ab_ensure_slot_launcher "$dir"
 
   # --- extensions (build + test against THIS candidate) --------------------
   local exts _e ev=()
@@ -508,6 +511,21 @@ cmd_switch() {
   ab_log "  verifying launcher boots from new current..."
   # shellcheck disable=SC2086
   $(ab_boot_cmd "$dir") --version >/dev/null 2>&1 || { ab_warn "launcher boot failed — rolling back symlink immediately"; ln -sfn "$prev_target" "$AB_SOURCE/current"; ab_die "rollback symlink restored to $prev_target"; }
+  # the `dsh` command itself must keep working after cutover: its chain
+  # (command -v dsh -> current/bin/dsh) resolves against the NEW current.
+  # 20260811+ snapshots removed bin/dsh; prepare materializes a slot launcher,
+  # so this should hold — fail loudly instead of shipping a broken `dsh`.
+  local _dsh _dsh_resolved
+  _dsh=$(command -v dsh || true)
+  if [ -n "$_dsh" ]; then
+    _dsh_resolved=$(resolve_link "$_dsh")
+    ab_log "  launcher chain: $_dsh -> $_dsh_resolved (current -> $dir)"
+    if [ -x "$dir/bin/dsh" ] || [ -x "$dir/apps/cli/lib/bin.js" ]; then
+      ab_log "  launcher chain OK: bootable entry present in new current"
+    else
+      ab_warn "  launcher chain will break: $dir has no bin/dsh and no lib/bin.js — run 'ab.sh prepare --slot $slot' to materialize the slot launcher"
+    fi
+  fi
   ab_state_set --arg slot "$slot" --arg prev "$prev_slot" --arg prevtarget "$prev_target" --arg at "$at" --arg snap "$(ab_state_get '.candidateSnapshot')" '
     .current = $slot | .phase = "switched" | .confirmed = false
     | .lastSwitch = { at: $at, from: $prev, to: $slot, previousTarget: $prevtarget, snapshot: $snap }
@@ -581,6 +599,13 @@ ab_restart_web() {
   # node bin dir from the current shell and use the resolved launcher path.
   local node_bin="" boot_dir
   command -v node >/dev/null 2>&1 && node_bin=$(dirname "$(command -v node)")
+  if [ -z "$node_bin" ]; then
+    # fallback when `node` is not on this shell's PATH (nohup subshells and
+    # launchd/guard contexts often have a minimal PATH): common install dirs.
+    for _nb in /opt/homebrew/bin /usr/local/bin; do
+      [ -x "$_nb/node" ] && { node_bin="$_nb"; break; }
+    done
+  fi
   log="$AB_SOURCE/web.log"
   # restart boots the NEW current (the symlink was already cut over)
   boot_dir=$(readlink "$AB_SOURCE/current" 2>/dev/null || echo "$AB_CURRENT")

--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -91,7 +91,7 @@ cmd_status() {
   done
   ab_log "phase: $phase  current-slot: ${cur:-<unset>}  confirmed: $confirmed"
   local wp
-  wp=$(ps aux | grep '[b]in.ts web' | head -2 | awk '{print $2, $9, $11, $12, $13}' | tr '\n' '; ')
+  wp=$(ps aux | grep -E '[b]in\.ts web|apps/cli/[l]ib/bin\.js web' | head -2 | awk '{print $2, $9, $11, $12, $13}' | tr '\n' '; ')
   ab_log "running web: ${wp:-<none>}"
   if [ -f "$AB_CONFIG_FILE" ]; then
     ab_log "extensions:"
@@ -538,10 +538,60 @@ cmd_switch() {
 }
 
 cmd_confirm() {
+  # Production-acceptance gate (2026-08-11 incident): confirming means "the
+  # RUNNING version is verifiably healthy through the PRODUCTION path" — not
+  # just "the user said ok". Reject the confirm unless:
+  #   1. the production port answers HTTP 200,
+  #   2. the running web process actually comes from the current slot,
+  #   3. the `dsh` launcher chain resolves into the current slot,
+  #   4. every configured extension client id is in the production boot manifest.
+  local port code cur dir proc html cids cid ok=1 launcher resolved
+  port=$(ab_config_get '.web.productionPort // 3080')
+  cur=$(ab_current_slot); dir=$(ab_slot_dir "$cur")
+  ab_log "production acceptance (confirm gate) on http://127.0.0.1:$port ..."
+  code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://127.0.0.1:$port/" 2>/dev/null || echo 000)
+  if [ "$code" = "200" ]; then
+    ab_ok "  production HTTP 200"
+  else
+    ab_err "  production web on :$port not answering HTTP 200 (got $code)"
+    ok=0
+  fi
+  # the running process may reference the slot by its real path OR through the
+  # `current` symlink (both mean "running the current slot's code").
+  proc=$(ps aux | grep -E '[b]in\.ts web|apps/cli/[l]ib/bin\.js web' | grep -E "$dir|$AB_SOURCE/current" | head -1 || true)
+  if [ -n "$proc" ]; then
+    ab_ok "  running web process from current slot $dir"
+  else
+    ab_err "  no running web process from current slot $dir"
+    ok=0
+  fi
+  launcher=$(command -v dsh || true)
+  if [ -n "$launcher" ]; then
+    resolved=$(resolve_link "$launcher")
+    case "$resolved" in
+      "$dir"/*|"$AB_SOURCE/current"/*) ab_ok "  launcher chain -> $resolved (inside current slot)" ;;
+      *) ab_err "  launcher chain resolves to $resolved (outside current slot $dir)"; ok=0 ;;
+    esac
+  else
+    ab_warn "  no 'dsh' on PATH — skipping launcher-chain check"
+  fi
+  cids=$(ab_config_get '.web.smokeClientIds // [] | .[]')
+  if [ -n "$cids" ]; then
+    html=$(curl -s --max-time 10 "http://127.0.0.1:$port/" 2>/dev/null || true)
+    for cid in $cids; do
+      if printf '%s' "$html" | grep -q "\"id\":\"$cid\""; then
+        ab_ok "  client manifest: $cid present"
+      else
+        ab_err "  client manifest: $cid MISSING on production"
+        ok=0
+      fi
+    done
+  fi
+  [ "$ok" = "1" ] || ab_die "production acceptance FAILED — do not confirm an unverifiable version; fix the running deployment and re-run confirm"
   local at; at=$(ab_now)
   ab_state_set --arg at "$at" '.confirmed = true | .history += [{ at: $at, action: "confirm" }]'
   ab_save_state
-  ab_ok "current marked confirmed — the rollback slot may now be recycled by the next prepare"
+  ab_ok "current marked confirmed (production-accepted) — the rollback slot may now be recycled by the next prepare"
 }
 
 cmd_rollback() {
@@ -576,7 +626,7 @@ cmd_rollback() {
 ab_restart_web() {
   local port pid i code log cwd pids
   port=$(ab_config_get '.web.productionPort // 3080')
-  pids=$(ps aux | grep '[b]in.ts web' | awk '{print $2}')
+  pids=$(ps aux | grep -E '[b]in\.ts web|apps/cli/[l]ib/bin\.js web' | awk '{print $2}')
   if [ -n "$pids" ]; then
     ab_warn "  stopping running dsh web instance(s): $(printf '%s' "$pids" | tr '\n' ' ')"
     for pid in $pids; do kill -TERM "$pid" 2>/dev/null || true; done

--- a/skills/dsh-snapshot-ab/scripts/lib/common.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/common.sh
@@ -214,11 +214,13 @@ ab_git_clean() { # "$1" dir → true if no tracked modifications
 # ab_detect_web — list every running dsh web instance as "pid port" lines.
 # A second instance shares ~/.dsh (sessions/storages) with the production one;
 # booting one is only safe for short read-only inspection. Port defaults 3080.
+# Matches both launch styles: tsx source (apps/cli/src/bin.ts web) and the
+# compiled CLI (apps/cli/lib/bin.js web, 20260811+ production entry).
 # NB: avoid `grep | head` pipelines here — under `set -o pipefail` head's early
 # close SIGPIPEs grep and the command substitution fails (set -e aborts).
 ab_detect_web() {
   local line pid port
-  ps aux | grep '[b]in.ts web' | while IFS= read -r line; do
+  ps aux | grep -E '[b]in\.ts web|apps/cli/[l]ib/bin\.js web' | while IFS= read -r line; do
     [ -n "$line" ] || continue
     pid=$(printf '%s\n' "$line" | awk '{print $2}')
     port=$(printf '%s\n' "$line" | sed -n 's/.*--port \([0-9][0-9]*\).*/\1/p')

--- a/skills/dsh-snapshot-ab/scripts/lib/common.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/common.sh
@@ -141,24 +141,66 @@ ab_other_slot() {
 
 ab_is_initialized() { [ "$(ab_state_get '.current // ""')" != "" ]; }
 
-# ab_boot_cmd <dir> — command line that boots this slot's dsh CLI.
-# 0810-era slots ship bin/dsh (a tsx wrapper); the 20260811 snapshot removed it
-# (source-run without a managed installer), so fall back to the same recipe the
-# old wrapper used, anchored to the slot by absolute paths + the tsconfig hook.
+# ab_boot_cmd <dir> — command line that boots this slot's dsh CLI in the SAME
+# way production runs it. Order matters:
+#   1. bin/dsh        — the launcher chain (~/.local/bin/dsh -> current/bin/dsh)
+#                       uses it; 0810-era slots ship it (a tsx wrapper).
+#   2. apps/cli/lib/bin.js — 20260811+ removed bin/dsh; production runs the
+#                       COMPILED CLI entry (pure node ESM, no tsconfig paths,
+#                       no tsx). Booting a candidate through tsx instead hides
+#                       runtime resolution gaps: tsx applies tsconfig paths, so
+#                       an extension dep that is missing from node_modules (but
+#                       present in the slot's packages or via paths) passes the
+#                       smoke test and then kills the real server with
+#                       ERR_MODULE_NOT_FOUND (2026-08-11 dsh-llm incident).
+#   3. tsx source     — last resort only when nothing was built.
 # Callers expand it UNQUOTED inside their subshell (paths contain no spaces).
 ab_boot_cmd() {
   local dir="$1"
   if [ -x "$dir/bin/dsh" ]; then
     printf '%s\n' "$dir/bin/dsh"
+  elif [ -x "$dir/apps/cli/lib/bin.js" ]; then
+    printf '%s\n' "$dir/apps/cli/lib/bin.js"
   else
     printf 'env NODE_USE_ENV_PROXY=1 TSX_TSCONFIG_PATH=%s/tsconfig.json node --import %s/node_modules/tsx/dist/esm/index.mjs %s/apps/cli/src/bin.ts\n' "$dir" "$dir" "$dir"
   fi
 }
 
 # ab_slot_usable <dir> — true when the slot has a bootable CLI: bin/dsh
-# (0810-era) or the tsx source entry (20260811+ removed bin/dsh).
+# (0810-era), the compiled CLI entry (20260811+), or the tsx source entry.
 ab_slot_usable() {
-  [ -x "$1/bin/dsh" ] || [ -f "$1/apps/cli/src/bin.ts" ]
+  [ -x "$1/bin/dsh" ] || [ -x "$1/apps/cli/lib/bin.js" ] || [ -f "$1/apps/cli/src/bin.ts" ]
+}
+
+# ab_ensure_slot_launcher <dir> — 20260811+ snapshots removed bin/dsh from the
+# tree; the launcher chain (~/.local/bin/dsh -> current/bin/dsh) then breaks
+# after a cutover ("dsh: command not found", 2026-08-11). Materialize a
+# slot-local bin/dsh wrapper that boots the compiled CLI entry, so the chain
+# stays valid on every slot. Idempotent; call after building a slot.
+ab_ensure_slot_launcher() {
+  local dir="$1"
+  [ -x "$dir/bin/dsh" ] && return 0
+  [ -x "$dir/apps/cli/lib/bin.js" ] || return 0
+  mkdir -p "$dir/bin"
+  cat > "$dir/bin/dsh" <<'EOF'
+#!/bin/sh
+# slot launcher for snapshots without bin/dsh (20260811+): boots the compiled
+# CLI entry apps/cli/lib/bin.js (production node ESM). Managed by ab.sh
+# (ab_ensure_slot_launcher); do not edit — it is regenerated on prepare.
+set -eu
+script=$0
+while [ -L "$script" ]; do
+  target=$(readlink "$script")
+  case $target in
+    /*) script=$target ;;
+    *) script=$(dirname "$script")/$target ;;
+  esac
+done
+root=$(CDPATH='' cd -- "$(dirname -- "$script")/.." && pwd)
+exec node "$root/apps/cli/lib/bin.js" "$@"
+EOF
+  chmod +x "$dir/bin/dsh"
+  ab_log "  slot launcher -> $dir/bin/dsh (compiled CLI entry)"
 }
 
 # ---- misc -------------------------------------------------------------------

--- a/skills/dsh-snapshot-ab/scripts/lib/extension.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/extension.sh
@@ -97,6 +97,68 @@ ext_install_skills() {
   done
 }
 
+# ext_check_runtime_deps <ext-json> <candidate-dir> <ext-repo>
+#   Production node ESM resolves the extension's @deepseek-ai/* / cordis imports
+#   ONLY through the extension's node_modules (ab-config relink links). The
+#   build/test gates resolve the same specifiers through tsconfig paths and
+#   vitest aliases — which do NOT exist at runtime — so a package missing from
+#   the relink map passes every gate and then kills the server with
+#   ERR_MODULE_NOT_FOUND after cutover (2026-08-11 dsh-llm incident: import was
+#   added in the extension, tsconfig/vitest already listed it, ab-config.relink
+#   did not). Scan the built lib for bare specifiers and fail the prepare with a
+#   precise missing-link list. lib/client.js is excluded: the client bundle is
+#   injected by the profile pnpm closure, not the relink map.
+ext_check_runtime_deps() {
+  local ext="$1" cand="$2" repo="$3"
+  local name libdir
+  name=$(printf '%s' "$ext" | jq -r '.name')
+  libdir="$repo/lib"
+  [ -d "$libdir" ] || { ab_warn "  runtime-deps: no $libdir — skipping"; return 0; }
+  local missing="" spec tmpfile
+  tmpfile="$(mktemp -t dsh-ab-extdeps.XXXXXX)"
+  # NB: a heredoc inside <( ) breaks bash parsing — scan to a temp file instead.
+  python3 - "$libdir" > "$tmpfile" <<'PY' || { rm -f "$tmpfile"; return 1; }
+import os, re, sys
+root = sys.argv[1]
+pat = re.compile(r"""(?:^|\b)(?:import|export)\s+(?:[^'"\n]*?\s+from\s+)?['"]([^'"]+)['"]""")
+pat2 = re.compile(r"""import\s*\(\s*['"]([^'"]+)['"]\s*\)""")
+seen = set()
+for base, _dirs, files in os.walk(root):
+    for f in files:
+        if not f.endswith(".js") or f == "client.js":
+            continue
+        if "/types/" in base or base.endswith("/types"):
+            continue
+        p = os.path.join(base, f)
+        try:
+            text = open(p, encoding="utf-8").read()
+        except OSError:
+            continue
+        for m in list(pat.finditer(text)) + list(pat2.finditer(text)):
+            s = m.group(1)
+            if s and (s.startswith("@deepseek-ai/") or s == "cordis"):
+                seen.add(s)
+for s in sorted(seen):
+    print(s)
+PY
+  while IFS= read -r spec; do
+    [ -n "$spec" ] || continue
+    if [ ! -e "$repo/node_modules/$spec" ]; then
+      missing="$missing $spec"
+    fi
+  done < "$tmpfile"
+  rm -f "$tmpfile"
+  if [ -n "$missing" ]; then
+    ab_err "  runtime-deps: $name imports packages missing from $repo/node_modules (production node ESM will fail at boot):"
+    for m in $missing; do ab_err "    $m"; done
+    ab_err "  fix: add each to ab-config.json extensions[].relink, e.g. \"node_modules/$m\": \"packages/<pkg-dir>\""
+    ab_err "  (build/test pass via tsconfig paths / vitest aliases, so only this gate catches it)"
+    return 1
+  fi
+  ab_ok "  runtime-deps: all @deepseek-ai/cordis imports resolvable via node_modules"
+  return 0
+}
+
 # ext_prepare <ext-json> <candidate-dir>
 #   Attach + build + test one extension against the candidate. On failure,
 #   restores relink + tsconfig and returns non-zero.
@@ -113,6 +175,7 @@ ext_prepare() {
   if ! ext_run "$ext" "$cand" "$repo" "typecheck"; then ok=0; fi
   if [ "$ok" = "1" ] && ! ext_run "$ext" "$cand" "$repo" "build"; then ok=0; fi
   if [ "$ok" = "1" ] && ! ext_run "$ext" "$cand" "$repo" "test"; then ok=0; fi
+  if [ "$ok" = "1" ] && ! ext_check_runtime_deps "$ext" "$cand" "$repo"; then ok=0; fi
   if [ "$ok" = "1" ]; then
     ext_install_skills "$ext" "$repo"
     ab_ok "extension $name OK against $cand"


### PR DESCRIPTION
## 为什么（2026-08-11 事故教训落地）

事故教训：**验收必须走生产等价路径；确认（confirm）同样必须基于生产验收**。原 `ab.sh confirm` 只是用户口头背书 + 写 `confirmed=true`——0811 那次正是"dryrun 全绿 + 口头说安全"然后生产起不来。

## 做了什么

1. **`ab.sh confirm` = 生产验收 gate**：确认前必须四项全过——
   - 生产端口 HTTP 200
   - 运行中的 web 进程来自当前槽（argv 为槽真实路径或 `current` 符号路径均算）
   - `dsh` launcher 链解析进当前槽
   - 配置的扩展 client id 出现在生产 boot manifest
   任一失败 → **拒绝确认**（ab_die），修复后重跑。
2. **进程匹配修复**：`ab_detect_web` / restart / status 同时匹配两种启动形态——tsx 源码（`apps/cli/src/bin.ts web`）与编译产物（`apps/cli/lib/bin.js web`，0811+ 生产入口）。之前只匹配 bin.ts，编译入口起的服务对 coexist/restart 逻辑不可见。
3. **复盘文档入库（双语）**：`references/postmortem-ab-switch-20260811.md` + `.en.md`（根因链：paths/alias/tsx 解析 vs 生产纯 node ESM、launcher 断链被 tsx 兜底掩盖；三条铁律）。SKILL.md confirm 语义同步更新。

## 验收（实测）

- 生产验收拒绝场景：进程 argv 用 `current/...` 符号路径时曾误报"不在当前槽"→ 修正匹配后四项全绿。
- 当前版本 `ab.sh confirm`：HTTP 200 ✅ / 进程来自 slot-a ✅ / launcher 链进当前槽 ✅ / dsh-track manifest ✅ → confirmed=true（20260812T013515Z）。
