### PR TITLE
docs(release): official private-npm reality + hub listing compliance

### DIFF
--- a/docs/RELEASE.en.md
+++ b/docs/RELEASE.en.md
@@ -158,9 +158,19 @@ bash skills/dsh-web-guard/scripts/install.sh   # optional: self-healing daemon
    published. Adding npm for one sub-component means a whole extra semver/CI/permission
    surface for little gain.
 3. Today, `private: true` + profile pnpm links already cover local/team installs.
+4. **The official npm presence is a private restricted scope** (researched 2026-08-12):
+   the official monorepo publishes to npmjs.com under the `@deepseek-ai` **private scope**
+   (211 packages, `0.0.1-rc.1`, NPM_TOKEN access, GitHub Actions manual dispatch from
+   `dsh-v*` tags). The public-npm 404s are the restricted design, not "not published".
+   **Third parties (us) currently have no access to that private registry** (even the
+   official devDep `dsh-repository-plugin` is still 404 there), so neither public nor
+   private npm is realistic for third-party plugins today.
 
 ### When it WOULD be worth publishing to npm (any of these):
 
+- **Official private registry opens to the org** (the official decision notes call the
+  private npm lib the future mainstream distribution: `npx -p @deepseek-ai/dsh@0.0.1-rc.1 dsh web`)
+  — then follow the official channel;
 - **Public distribution** of the bundle to users outside the org (git install forces
   them to `allowBuilds`; npm prebuilt avoids that friction);
 - **Semver range resolution** in profiles (`^0.2.0` instead of a pinned commit);
@@ -169,6 +179,26 @@ bash skills/dsh-web-guard/scripts/install.sh   # optional: self-healing daemon
 Then publish only `plugins/dsh-restart-recover` (drop `private: true`, build `lib/`
 before `pnpm publish`). The repo-level version (VERSION/tag) and the npm package
 version can evolve independently.
+
+---
+
+## 4. Hub listing (automatic after release; keep it compliant)
+
+- **Mechanism** (dsh-external/hub, private): `catalog.source.json` (human classification
+  layer) + `scripts/generate.mjs` (automatic layer: GitHub API metadata, refreshed by a
+  local **Agent Loop every 2 hours**; currently 241 repos).
+- Unclassified repos get a "please add to catalog.source.json" warning — classification
+  is not required for release, but recommended.
+- **description / topics compliance** (official template):
+  - description: one line "what it is + how to install", template
+    `DSH plugin: <what it does>; install via <install-command>`;
+  - topics: ecosystem tags (`dsh` / `deepseek-harness`, add `dsh-bundle` for bundles) +
+    functional tags, 3–6 total; `gh repo edit <owner>/<repo> --add-topic ...`.
+- **Self-check** (2026-08-12): dsh-harness-ops topics are compliant (6:
+  `deepseek-harness` `dsh` `ops` `restart` `self-heal` `snapshot-ab`); the description
+  says what it is but lacks "how to install" — add
+  `install via: git clone + bash scripts/install.sh` at the next revision. The repo is
+  visible in the hub automatic layer; manual classification not yet in catalog.source.json.
 
 ---
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -138,15 +138,39 @@ bash skills/dsh-web-guard/scripts/install.sh   # 可选：自愈守护
    **无法用 npm 分发**；能 publish 的只有 `plugins/dsh-restart-recover` 这一个 bundle 包。
    为一个子组件引入 npm 发布 = 多一套 semver/CI/权限管理，收益有限。
 3. 目前 `private: true` + profile pnpm link 已经满足本机/团队安装。
+4. **官方自身的 npm 是私有 restricted scope**（2026-08-12 调研确认）：官方主仓库发布到
+   npmjs.com 的 `@deepseek-ai` **私有 scope**（211 包、`0.0.1-rc.1`、NPM_TOKEN 访问、
+   GitHub Actions 从 `dsh-v*` tag 手动 dispatch）。公共 npm 全 404 是 restricted 设计，
+   不是"没发布"。**第三方（我们）目前拿不到私有库访问权**（官方 devDep
+   `dsh-repository-plugin` 在私有库都仍 404），所以公共/私有 npm 对第三方插件都不现实。
 
 ### 何时值得进 npm（触发条件，满足其一再动）：
 
-- **公开分发** bundle 给 org 外用户（GitHub 直装要用户手动 `allowBuilds`，npm 预构建免这一步）；
+- **官方开放私有库给 org**（未来主流分发据官方决策笔记是私有 npm 库
+  `npx -p @deepseek-ai/dsh@0.0.1-rc.1 dsh web`）——届时跟随官方通道；
+- **公开分发** bundle 给 org 外用户（git 安装要用户 `allowBuilds`，npm 预构建免这一步）；
 - 需要 **semver range 依赖解析**（profile 里写 `^0.2.0` 而不是 pin commit）；
 - 需要 **pnpm pack tarball** 给离线环境。
 
 届时只 publish `plugins/dsh-restart-recover`（去掉 `private: true`、`pnpm publish` 前构建 lib/），
 仓库级版本（VERSION/tag）与 npm 包版本可各自独立演进。
+
+---
+
+## 四、hub 收录（发布后自动生效，注意合规）
+
+- **机制**（dsh-external/hub，私有）：`catalog.source.json`（人工分类层）+ `scripts/generate.mjs`
+  （自动层：GitHub API 抓 description/language/updated，**Agent Loop 每 2 小时刷新**，当前 241 仓库）。
+- 未在 `catalog.source.json` 人工分类的仓库会生成"请加入分类"警告——分类不是发布必需，但建议补。
+- **description / topics 合规**（官方模板）：
+  - description 一行「是什么 + 怎么装」，模板：
+    `DSH plugin: <what it does>; install via <install-command>`；
+  - topics：生态标签（`dsh` / `deepseek-harness`，bundle 加 `dsh-bundle`）+ 功能标签，共 3–6 个；
+  - `gh repo edit <owner>/<repo> --add-topic ...`。
+- **现状自查**（2026-08-12）：dsh-harness-ops topics 6 个合规
+  （`deepseek-harness` `dsh` `ops` `restart` `self-heal` `snapshot-ab`）；description 有"是什么"
+  缺"怎么装"——下次修订补 `install via: git clone + bash scripts/install.sh`。
+  仓库在 hub 自动层可见，人工分类尚未加入 catalog.source.json。
 
 ---
 


### PR DESCRIPTION
Research addendum to the release policy (RELEASE.md / .en.md): official monorepo publishes to a PRIVATE restricted @deepseek-ai npm scope; hub listing mechanism; description updated with install command.