### PR TITLE
chore(release): align dsh-restart-recover version with repo v0.2.0

### DIFF
--- a/plugins/dsh-restart-recover/package.json
+++ b/plugins/dsh-restart-recover/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@deepseek-ai/dsh-restart-recover",
   "description": "Restart recovery for dsh web: after a crash/restart, an interrupted agent turn continues automatically (host-side agent/created listener — no browser timing races). Pairs with the dsh-web-guard skill (which auto-relaunches the web process); together they make restart self-healing.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
Bundle package version aligns with the repo-level VERSION (first tagged release v0.2.0). Profile link: install is unaffected.