### PR TITLE
feat(web-doctor): out-of-band doctor for web/A/B total outages

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,12 +11,15 @@ English | [中文](README.md)
 > | **`skills/dsh-snapshot-ab`** | skill | Daily upstream-snapshot A/B dual-slot rotation — "switch to the right version" on upgrade |
 > | **`skills/dsh-web-guard`** | skill | Self-healing guard — auto-restarts web within 10s of it dying |
 > | **`skills/dsh-session-recovery`** | skill | Session-loss diagnosis — locate & losslessly repair "0 sessions" / corrupted logs |
+> | **`skills/dsh-web-doctor`** | skill | Out-of-band doctor — one terminal command to diagnose → fix → relaunch when web/A/B are all down |
 > | **`plugins/dsh-restart-recover`** | cordis plugin | Restart continuation — an interrupted turn resumes automatically |
 >
-> Together they answer four questions: **who brings web back up when it dies? Does work
+> Together they answer five questions: **who brings web back up when it dies? Does work
 > continue after restart? What if sessions seem lost? How do we switch versions safely
-> when the official release arrives?** They complement each other:
-> `ab.sh switch/rollback` kills web → `dsh-web-guard` brings it back → `dsh-restart-recover` continues the turn.
+> when the official release arrives? How do we rescue a total A/B outage with one
+> command?** They complement each other:
+> `ab.sh switch/rollback` kills web → `dsh-web-guard` brings it back → `dsh-restart-recover` continues the turn;
+> the last-resort fallback for a total outage is `dsh-web-doctor` (`doctor.sh --fix --restart`).
 >
 > > Formerly `dsh-skill-snapshot-ab` (renamed 2026-08-11) — the repo grew from a
 > > pure AB-rotation skill into a mixed "skill + plugin" toolbox, so the old name no
@@ -37,7 +40,9 @@ dsh-harness-ops (this repo)
 ├── skills/dsh-web-guard/          self-healing guard: launchd/systemd hosted, brings web up within 10s of a free port
 │   └── scripts/install.sh         cross-platform install (macOS launchd / Linux systemd)
 ├── skills/dsh-session-recovery/   session-loss diagnosis: 0 sessions/corrupted logs → locate → lossless repair → restart
-│   └── scripts/                   validate-sessions / repair-session-log / check-all-sessions
+│   └── scripts/                   validate-sessions / repair-session-log / check-all-sessions / repair-unknown-events
+├── skills/dsh-web-doctor/        out-of-band doctor: diagnose → fix → relaunch from the terminal when web/A/B are all down
+│   └── scripts/                   doctor.sh / session-last-activity.mjs
 └── plugins/dsh-restart-recover/   restart-continuation plugin: detects interrupted on agent/created → auto-injects continuation
     └── src/index.ts               cordis plugin (listens agent/created, zero dsh-track dependency)
 ```

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@
 > | **`skills/dsh-snapshot-ab`** | skill | 官方每日快照 A/B 双槽轮换 —— 升级"切对版本" |
 > | **`skills/dsh-web-guard`** | skill | 自愈守护 —— web 死后 10s 自动拉起 |
 > | **`skills/dsh-session-recovery`** | skill | 会话丢失诊断 —— “0 sessions”/日志损坏时的定位与无损修复 |
+> | **`skills/dsh-web-doctor`** | skill | out-of-band 医生 —— web/A/B 全挂时终端一键诊断→修复→拉起 |
 > | **`plugins/dsh-restart-recover`** | cordis 插件 | 重启续接 —— 被中断的 turn 自动继续 |
 >
-> 合起来回答四个问题：**web 挂了谁拉起？拉起后工作继续吗？会话看起来丢了怎么办？官方发新版本怎么安全切换？**
-> 三者互补：`ab.sh switch/rollback` 杀 web → `dsh-web-guard` 拉起 → `dsh-restart-recover` 续接。
+> 合起来回答五个问题：**web 挂了谁拉起？拉起后工作继续吗？会话看起来丢了怎么办？官方发新版本怎么安全切换？A/B 都挂了怎么一键救？**
+> 三者互补：`ab.sh switch/rollback` 杀 web → `dsh-web-guard` 拉起 → `dsh-restart-recover` 续接；
+> 全挂兜底走 `dsh-web-doctor`（终端 `doctor.sh --fix --restart`）。
 >
 > > 曾用名 `dsh-skill-snapshot-ab`（2026-08-11 更名）—— 仓库从"纯 AB 轮换 skill"长成了
 > > "skill + 插件"混合工具箱，名字不再贴切。skill 目录名 `dsh-snapshot-ab` 保持不变
@@ -32,7 +34,9 @@ dsh-harness-ops（本仓库）
 ├── skills/dsh-web-guard/          自愈守护：launchd/systemd 托管，端口空闲 10s 内拉起 web
 │   └── scripts/install.sh         跨平台安装（macOS launchd / Linux systemd）
 ├── skills/dsh-session-recovery/  会话丢失诊断：0 sessions/日志损坏 → 定位 → 无损修复 → 重启
-│   └── scripts/                   validate-sessions / repair-session-log / check-all-sessions
+│   └── scripts/                   validate-sessions / repair-session-log / check-all-sessions / repair-unknown-events
+├── skills/dsh-web-doctor/        out-of-band 医生：web/A/B 全挂时终端一键诊断→修复→拉起
+│   └── scripts/                   doctor.sh / session-last-activity.mjs
 └── plugins/dsh-restart-recover/   重启续接插件：agent/created 检测 interrupted → 自动注入续接
     └── src/index.ts               cordis 插件（监听 agent/created，零 dsh-track 依赖）
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,7 @@ echo "[dsh-harness-ops] installing v$VERSION from $ROOT"
 # --- 1) skills --------------------------------------------------------------
 mkdir -p "$SKILLS_DST"
 installed=0
-for s in dsh-snapshot-ab dsh-web-guard dsh-session-recovery; do
+for s in dsh-snapshot-ab dsh-web-guard dsh-session-recovery dsh-web-doctor; do
   src="$ROOT/skills/$s"
   [ -d "$src" ] || { echo "  warn: skill dir missing: $src"; continue; }
   rm -rf "$SKILLS_DST/$s"

--- a/skills/dsh-web-doctor/SKILL.md
+++ b/skills/dsh-web-doctor/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: dsh-web-doctor
+description: >-
+  dsh web 挂了/A/B 双槽都起不来时的 out-of-band 医生：不依赖 web 进程，纯终端一键诊断
+  （web 健康、launcher 链、扩展 relink、槽可启动性、session 存储、web.log、最近会话最后发生的事）
+  → 自动修复（relink 自愈、bin/dsh 补位、未知事件 ignorable、损坏日志修复）→ 把 web 拉回来并验证。
+  当用户说"web 挂了怎么查"、"dsh web 起不来"、"3080 挂了"、"怎么自愈"、"跑一下 doctor"、
+  "看看系统为什么挂了"时使用，即使 GUI/agent 都不可用（在终端跑 scripts/doctor.sh）。
+  English: out-of-band doctor for dsh web when it is down or won't boot (both A/B slots
+  broken, GUI/agent unavailable). One terminal command diagnoses (web health, launcher
+  chain, extension relinks, slot bootability, session store, web.log, last activity in
+  recent sessions), auto-fixes known issues (relink self-heal, slot launcher, unknown
+  session-event ignorable marking, corrupt-log repair), then relaunches web and verifies
+  HTTP 200. Use when the user reports web down, dsh web failing to boot, 3080 not
+  responding, or asks for a doctor/self-heal run.
+---
+
+# dsh web Doctor（out-of-band 自愈）
+
+当 **web（3080）挂了或起不来**——包括 A/B 双槽都坏、GUI/agent 都不可用的最坏情况——用本
+skill。它是 **out-of-band** 的：只靠终端 + 本机工具（node/zstd/jq/curl/ps/lsof）和已安装
+skills 的脚本，**不依赖任何 web 进程**。
+
+诞生背景（2026-08-11）：切换事故 + 扩展链接消失事故的现场修复（查 session → 找根因 →
+修 relink/会话 → 拉起 web）每一步都能脚本化，但缺一个不依赖 web 的一键入口——浪费了数小时
+人工。本 skill 把它自动化。
+
+## 何时用
+
+- `dsh web` 起不来 / 3080 无响应 / 白屏。
+- A/B 槽切换后 web 没起来（cutover 成功但 restart 失败）。
+- 报错形如：`ERR_MODULE_NOT_FOUND: @deepseek-ai/...`（扩展 relink 缺失）、
+  `dsh: command not found`（launcher 链断）、`SessionFormatUnsupportedError ... unknown ...
+  not marked ignorable`（会话未知事件）、`corrupt Zstandard session log`。
+- 用户问"系统为什么挂了 / 怎么自愈 / 跑一下 doctor"。
+- **web 挂时 agent 也不可用**（agent 由 web 托管）——直接让用户在终端跑 doctor.sh，或把
+  本 skill 的自愈 prompt 粘给任何可用的 agent。
+
+## 用法
+
+```sh
+bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh             # 只诊断（只读）
+bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh --fix       # 诊断 + 自动修复
+bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh --fix --restart  # 诊断 + 修复 + 拉起 web
+```
+
+| Flag | 作用 |
+|---|---|
+| （无） | 只读诊断，报告问题清单（exit 0 全好 / exit 1 有问题） |
+| `--fix` | 自动修复：relink 自愈 → bin/dsh 补位 → 会话未知事件 ignorable → 损坏日志修复 → **verify 重查** |
+| `--restart` | 修复后拉起 web（kill 旧 + nohup 重启 + 轮询 HTTP 200）；web 已 200 则跳过 |
+
+## 诊断项（doctor 查什么）
+
+1. **web 健康**：`:3080` HTTP 状态。
+2. **launcher 链**：`command -v dsh` → 解析（接受 `current/...` 符号路径）。
+3. **扩展 relink**：ab-config 里每个 `extensions[].relink` 是否存在（缺失 = 未来 `dsh web`
+   必挂，正是 2026-08-11 事故）。
+4. **槽可启动**：current 有 `bin/dsh` 或编译产物 `apps/cli/lib/bin.js`。
+5. **session 存储**：全量 `check-all-sessions.mjs`（92 会话示例：全过）。
+6. **web.log 尾部**：最近启动失败的直接证据。
+7. **最近会话"最后发生的事"**：`session-last-activity.mjs` 列最近活跃会话的最后事件
+   （类型/seq/时间/内容提示）——"挂了之前系统在做什么"。
+
+## 自愈 prompt（web 恢复后 / 给其它 agent）
+
+用户（或任何可用 agent）把下面这段粘给恢复后的会话，即可接续排查：
+
+```text
+dsh web 之前挂了，已跑 doctor.sh 自愈。请：
+1. 看 doctor 报告：bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh
+2. 若还有残留问题：读 ~/.dsh/skills/dsh-session-recovery/SKILL.md（会话问题）和
+   ~/.dsh/skills/dsh-snapshot-ab/SKILL.md（A/B 切换问题）
+3. 用 session-last-activity 看挂之前的最后操作，定位人为/外部原因
+4. 修完验证：curl http://127.0.0.1:3080/ 应 200，ab.sh status 应正常
+```
+
+## 边界与安全
+
+- **只读诊断**永远安全；`--fix` 的每步都是可逆/有备份的（relink 重建、launcher 补位、
+  ignorable 标记——修复脚本自身做备份 + 校验 + 可回滚交换）。
+- doctor **不碰** web 进程内部的会话数据；重启走 `dsh-session-recovery/restart-dsh-web.sh`
+  （kill + nohup + 轮询）。
+- 依赖的脚本：`dsh-snapshot-ab`（ab.sh status 触发 relink 自愈）、`dsh-session-recovery`
+  （check-all-sessions / repair-unknown-events / repair-session-log / restart-dsh-web）。
+  这些 skill 需已安装（`dsh-harness-ops` 仓库 `scripts/install.sh`）。
+
+## 参考
+
+- 事故复盘：`dsh-snapshot-ab/references/postmortem-ab-switch-20260811.md`
+- 会话修复：`dsh-session-recovery/SKILL.md`
+- A/B 轮换：`dsh-snapshot-ab/SKILL.md`

--- a/skills/dsh-web-doctor/scripts/doctor.sh
+++ b/skills/dsh-web-doctor/scripts/doctor.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# dsh-web-doctor — OUT-OF-BAND diagnosis, repair and relaunch for dsh web.
+#
+# Use this when the web (3080) is down or won't boot — including when BOTH A/B
+# slots are broken — and the normal GUI/agent path is unavailable. It runs
+# entirely from the terminal with local tools (node/zstd/jq/curl/ps/lsof) and
+# the installed skills' scripts; it does NOT depend on a running web process.
+#
+# What it does, in order:
+#   1. environment + layout snapshot (current slot, ab-state, web, launcher)
+#   2. diagnosis: web health, launcher chain, extension relinks, slot bootable,
+#      session store health, web.log tail, and "what happened last" in the most
+#      recently active sessions
+#   3. --fix: apply known self-heals (relink recreate, slot launcher, unknown
+#      session-event ignorable marking, corrupt-log repair)
+#   4. --restart: relaunch dsh web and poll HTTP 200
+#   5. report: what was found, what was fixed, what still needs a human
+#
+# Usage:
+#   doctor.sh                 # diagnose only (read-only)
+#   doctor.sh --fix           # diagnose + auto-fix known issues
+#   doctor.sh --fix --restart # diagnose + fix + relaunch web
+#   doctor.sh --quiet         # less chatter
+#
+# Exit codes: 0 all-clear (or fixed+up); 1 diagnosis found problems;
+# 2 web not up after restart. Safe to re-run; every fix is reversible and
+# backed up by the underlying scripts.
+set -uo pipefail
+
+SKILLS_DIR="${DSH_SKILLS_DIR:-$HOME/.dsh/skills}"
+DSH_SOURCE="${DSH_SOURCE:-$HOME/.dsh/source}"
+AB="$SKILLS_DIR/dsh-snapshot-ab/scripts/ab.sh"
+REC="$SKILLS_DIR/dsh-session-recovery/scripts"
+PORT="${DSH_WEB_PORT:-3080}"
+
+FLAG_FIX=0; FLAG_RESTART=0; FLAG_QUIET=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --fix) FLAG_FIX=1; shift ;;
+    --restart) FLAG_RESTART=1; shift ;;
+    --quiet) FLAG_QUIET=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+say()  { [ "$FLAG_QUIET" = "1" ] || printf '%s\n' "$*"; }
+warn() { printf '\033[1;33m[doctor]\033[0m %s\n' "$*" >&2; }
+err()  { printf '\033[1;31m[doctor]\033[0m %s\n' "$*" >&2; }
+ok()   { printf '\033[1;32m[doctor]\033[0m %s\n' "$*"; }
+info() { printf '\033[1;34m[doctor]\033[0m %s\n' "$*"; }
+
+PROBLEMS=0
+note_problem() { PROBLEMS=$((PROBLEMS + 1)); }
+
+# --- 1. environment ----------------------------------------------------------
+info "dsh-web-doctor (out-of-band) — port $PORT"
+missing=""
+for t in node zstd jq curl ps lsof; do
+  command -v "$t" >/dev/null 2>&1 || missing="$missing $t"
+done
+if [ -n "$missing" ]; then
+  err "missing required tools:$missing — doctor cannot run"
+  exit 2
+fi
+
+# --- 2. layout snapshot ------------------------------------------------------
+CURRENT="<none>"
+[ -L "$DSH_SOURCE/current" ] && CURRENT=$(readlink "$DSH_SOURCE/current")
+info "current: $CURRENT"
+if [ -f "$DSH_SOURCE/ab-state.json" ]; then
+  python3 - "$DSH_SOURCE/ab-state.json" <<'PY' | while IFS= read -r line; do say "$line"; done
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(f"  phase={d.get('phase')} current-slot={d.get('current')} confirmed={d.get('confirmed')}")
+PY
+fi
+[ -n "$CURRENT" ] || { err "no current symlink — the A/B layout is missing"; note_problem; }
+
+# --- 3. diagnosis ------------------------------------------------------------
+echo
+info "== diagnosis =="
+
+# 3a. web health
+code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
+if [ "$code" = "200" ]; then
+  ok "web on :$PORT answers HTTP 200"
+else
+  err "web on :$PORT answers HTTP $code (not up)"
+  note_problem
+fi
+
+# 3b. launcher chain
+launcher=$(command -v dsh || true)
+if [ -n "$launcher" ]; then
+  resolved=$(readlink "$launcher" 2>/dev/null || echo "$launcher")
+  say "  launcher: $launcher -> $resolved"
+  # `current` is a symlink; readlink does not recurse, so accept both the
+  # real slot path and the `$DSH_SOURCE/current/...` spelling (which resolves
+  # to the current slot at exec time).
+  if [ -n "$CURRENT" ] && [[ "$resolved" != "$CURRENT/"* ]] && [[ "$resolved" != "$DSH_SOURCE/current/"* ]]; then
+    warn "launcher resolves outside current slot ($resolved)"
+  fi
+  if [ -f "$launcher" ] && [ ! -x "$launcher" ]; then
+    err "launcher exists but is not executable: $launcher"
+    note_problem
+  fi
+else
+  err "'dsh' not on PATH — launcher chain broken"
+  note_problem
+fi
+
+# 3c. extension relinks (against current)
+if [ -f "$DSH_SOURCE/ab-config.json" ]; then
+  echo
+  say "== extension relinks =="
+  python3 - "$DSH_SOURCE/ab-config.json" "$CURRENT" <<'PY' | while IFS= read -r line; do case "$line" in MISSING:*) err "${line#MISSING:}"; note_problem;; *) say "  $line";; esac; done
+import json, os, sys
+cfg, cur = sys.argv[1], sys.argv[2]
+d = json.load(open(cfg))
+for ext in d.get('extensions', []):
+    repo = ext.get('repo', '')
+    for link, rel in (ext.get('relink') or {}).items():
+        target = f"{repo}/{link}"
+        if not os.path.exists(target):
+            print(f"MISSING: relink {target} (needs -> {cur}/{rel})")
+        else:
+            print(f"ok: {link} -> {rel}")
+PY
+fi
+
+# 3d. slot bootable
+if [ -n "$CURRENT" ]; then
+  echo
+  say "== current slot bootability =="
+  if [ -x "$CURRENT/bin/dsh" ]; then
+    say "  bin/dsh present"
+  elif [ -x "$CURRENT/apps/cli/lib/bin.js" ]; then
+    warn "  no bin/dsh — compiled CLI present (launcher chain may still break if bin/dsh is what ~/.local/bin/dsh resolves to)"
+    note_problem
+  else
+    err "  current slot has neither bin/dsh nor apps/cli/lib/bin.js — not bootable"
+    note_problem
+  fi
+fi
+
+# 3e. session store health (lightweight: check-all-sessions)
+echo
+say "== session store =="
+if [ -f "$REC/check-all-sessions.mjs" ]; then
+  out=$(node "$REC/check-all-sessions.mjs" 2>&1)
+  rc=$?
+  tail_line=$(printf '%s\n' "$out" | tail -1)
+  if [ "$rc" = "0" ]; then
+    ok "sessions: $tail_line"
+  else
+    err "sessions: $tail_line"
+    note_problem
+  fi
+else
+  err "check-all-sessions.mjs missing — session store not checked"
+  note_problem
+fi
+
+# 3f. web.log tail
+if [ -f "$DSH_SOURCE/web.log" ]; then
+  echo
+  say "== web.log tail =="
+  tail -8 "$DSH_SOURCE/web.log" | sed 's/^/  /' >&2
+fi
+
+# 3g. what happened last (most recently active sessions)
+echo
+say "== last activity in recent sessions =="
+if [ -f "$SKILLS_DIR/dsh-web-doctor/scripts/session-last-activity.mjs" ]; then
+  node "$SKILLS_DIR/dsh-web-doctor/scripts/session-last-activity.mjs" --limit 4 2>&1 | sed 's/^/  /'
+fi
+
+# --- 4. repair ---------------------------------------------------------------
+if [ "$FLAG_FIX" = "1" ]; then
+  echo
+  info "== auto-fix =="
+
+  # 4a. relink + launcher self-heal via ab.sh status (idempotent, read-mostly)
+  if [ -x "$AB" ]; then
+    if "$AB" status >/dev/null 2>&1; then
+      ok "ab.sh status ran (relink self-heal active)"
+    else
+      warn "ab.sh status exited non-zero (see above)"
+    fi
+  fi
+
+  # 4b. slot launcher materialization (20260811+ slots have no bin/dsh)
+  if [ -n "$CURRENT" ] && [ ! -x "$CURRENT/bin/dsh" ] && [ -x "$CURRENT/apps/cli/lib/bin.js" ]; then
+    mkdir -p "$CURRENT/bin"
+    cat > "$CURRENT/bin/dsh" <<'LAUNCHER'
+#!/bin/sh
+# slot launcher for snapshots without bin/dsh (20260811+): boots the compiled
+# CLI entry apps/cli/lib/bin.js (production node ESM). Regenerated by
+# dsh-web-doctor / ab.sh prepare.
+set -eu
+script=$0
+while [ -L "$script" ]; do
+  target=$(readlink "$script")
+  case $target in
+    /*) script=$target ;;
+    *) script=$(dirname "$script")/$target ;;
+  esac
+done
+root=$(CDPATH='' cd -- "$(dirname -- "$script")/.." && pwd)
+exec node "$root/apps/cli/lib/bin.js" "$@"
+LAUNCHER
+    chmod +x "$CURRENT/bin/dsh"
+    ok "materialized $CURRENT/bin/dsh (compiled CLI entry)"
+  fi
+
+  # 4c. unknown session-event repair (ignorable marking)
+  if [ -f "$REC/repair-unknown-events.mjs" ]; then
+    node "$REC/repair-unknown-events.mjs" --all >/tmp/dsh-doctor-repair.log 2>&1
+    rc=$?
+    if [ "$rc" = "0" ] || [ "$rc" = "2" ]; then
+      tail -1 /tmp/dsh-doctor-repair.log | sed 's/^/  /'
+      ok "unknown-event repair pass complete"
+    else
+      err "unknown-event repair failed (see /tmp/dsh-doctor-repair.log)"
+      note_problem
+    fi
+  fi
+
+  # --- 4d. verify fixes (re-check what we just repaired) -----------------------
+  echo
+  info "== verify fixes =="
+  PROBLEMS=0
+  if [ -f "$DSH_SOURCE/ab-config.json" ] && [ -n "$CURRENT" ]; then
+    missing=$(python3 - "$DSH_SOURCE/ab-config.json" "$CURRENT" <<'PY'
+import json, os, sys
+cfg, cur = sys.argv[1], sys.argv[2]
+d = json.load(open(cfg))
+miss = 0
+for ext in d.get('extensions', []):
+    repo = ext.get('repo', '')
+    for link, _rel in (ext.get('relink') or {}).items():
+        if not os.path.exists(f"{repo}/{link}"):
+            print(f"  MISSING {repo}/{link}")
+            miss += 1
+sys.exit(1 if miss else 0)
+PY
+    )
+    rc=$?
+    if [ "$rc" = "0" ]; then
+      ok "all extension relinks present"
+    else
+      err "relinks still missing:"; printf '%s\n' "$missing" | sed 's/^/    /'
+      note_problem
+    fi
+  fi
+  if [ -n "$CURRENT" ] && { [ ! -x "$CURRENT/bin/dsh" ] && [ ! -x "$CURRENT/apps/cli/lib/bin.js" ]; }; then
+    err "current slot still not bootable"
+    note_problem
+  fi
+fi
+
+# --- 5. restart --------------------------------------------------------------
+if [ "$FLAG_RESTART" = "1" ]; then
+  echo
+  info "== relaunching dsh web (port $PORT) =="
+  code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
+  if [ "$code" = "200" ]; then
+    ok "web already up — skipping restart"
+  elif [ -f "$REC/restart-dsh-web.sh" ]; then
+    sh "$REC/restart-dsh-web.sh" 2>&1 | tail -6
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
+    if [ "$code" = "200" ]; then
+      ok "web is UP on :$PORT after restart"
+    else
+      err "web NOT up after restart (HTTP $code) — inspect the log tail above"
+      exit 2
+    fi
+  else
+    err "restart-dsh-web.sh missing — cannot relaunch"
+    exit 2
+  fi
+fi
+
+# --- 6. report ---------------------------------------------------------------
+echo
+info "== report =="
+if [ "$PROBLEMS" = "0" ]; then
+  ok "no problems found"
+  exit 0
+else
+  err "$PROBLEMS problem(s) found"
+  if [ "$FLAG_FIX" = "0" ]; then
+    say "  re-run with --fix to auto-repair, --restart to relaunch web"
+  fi
+  exit 1
+fi

--- a/skills/dsh-web-doctor/scripts/session-last-activity.mjs
+++ b/skills/dsh-web-doctor/scripts/session-last-activity.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * session-last-activity.mjs — "what happened last" for the most recently
+ * active sessions. Out-of-band (no web process needed): enumerates the
+ * session store, sorts by log mtime, and decodes the tail of each recent log
+ * to show the last event type/time/seq and a short content hint. Used by
+ * dsh-web-doctor to help a human (or a recovery agent) figure out what the
+ * system was doing right before it went down.
+ *
+ * Usage:
+ *   node session-last-activity.mjs [--limit N] [--tail N] [--root <sessions-root>]
+ */
+import { parseArgs } from 'node:util'
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+
+const { values } = parseArgs({
+  options: {
+    limit: { type: 'string', default: '4' },
+    tail: { type: 'string', default: '6' },
+    root: { type: 'string' },
+  },
+})
+const limit = Number(values.limit)
+const tailN = Number(values.tail)
+const root = values.root ?? join(homedir(), '.dsh', 'sessions')
+
+function listLogs() {
+  const out = []
+  let projects
+  try { projects = readdirSync(root, { withFileTypes: true }) } catch { return out }
+  for (const p of projects) {
+    if (!p.isDirectory()) continue
+    const pdir = join(root, p.name)
+    for (const s of readdirSync(pdir, { withFileTypes: true })) {
+      if (!s.isDirectory()) continue
+      const log = join(pdir, s.name, 'session.jsonl.zstd')
+      try { const st = statSync(log); out.push({ id: s.name, project: p.name, log, mtime: st.mtimeMs }) } catch { /* plaintext or missing */ }
+    }
+  }
+  return out.sort((a, b) => b.mtime - a.mtime)
+}
+
+function decodeTail(log, n) {
+  try {
+    const plain = execFileSync('zstd', ['-dc', log], { maxBuffer: 1024 * 1024 * 1024 }).toString('utf8')
+    const lines = plain.trimEnd().split('\n')
+    const tail = lines.slice(-n)
+    const events = []
+    for (const ln of tail) {
+      try {
+        const r = JSON.parse(ln)
+        // packed chunk rows expand to many events; report the row's type as-is
+        events.push({
+          type: r.type ?? '?',
+          seq: typeof r.seq === 'number' ? r.seq : undefined,
+          time: typeof r.time === 'number' ? new Date(r.time).toISOString().slice(11, 19) : undefined,
+          hint: hintOf(r),
+        })
+      } catch { /* skip non-JSON */ }
+    }
+    return events
+  } catch { return [] }
+}
+
+function hintOf(r) {
+  const t = r.type ?? ''
+  if (t === 'user/message') {
+    const c = r.data?.content
+    const text = Array.isArray(c) ? c.map(x => x?.text ?? '').join(' ') : String(c ?? '')
+    return text.slice(0, 80)
+  }
+  if (t === 'assistant/message' || t === 'assistant/chunk' || t === 'text-chunks') {
+    const c = r.data?.content ?? r.data?.text
+    const text = Array.isArray(c) ? c.map(x => x?.text ?? '').join(' ') : String(c ?? '')
+    return text.slice(0, 80)
+  }
+  if (t === 'tool/call') {
+    const a = r.data?.arguments ?? r.data?.input
+    return `tool ${r.data?.name ?? '?'} ${typeof a === 'string' ? a.slice(0, 60) : ''}`
+  }
+  if (t === 'tool/result') {
+    return 'tool result'
+  }
+  return ''
+}
+
+const logs = listLogs().slice(0, limit)
+for (const l of logs) {
+  const when = new Date(l.mtime).toISOString().replace('T', ' ').slice(0, 19)
+  console.log(`${l.id}  (${l.project}, touched ${when})`)
+  const evs = decodeTail(l.log, tailN)
+  for (const e of evs.reverse()) {
+    const seq = e.seq !== undefined ? ` #${e.seq}` : ''
+    const tm = e.time ? ` ${e.time}` : ''
+    const hint = e.hint ? ` — ${e.hint}` : ''
+    console.log(`    ${e.type}${seq}${tm}${hint}`)
+  }
+}
+if (logs.length === 0) console.log('(no zstd session logs found)')


### PR DESCRIPTION
## 为什么

2026-08-11 两次事故（切换后 web 起不来、扩展 relink 被清）的现场修复：查 session 找根因 → 修 relink → 修会话 → 拉起 web，每一步都能脚本化，但**没有不依赖 web 的一键入口**——GUI/agent 全不可用时（web 挂了 agent 也在 web 里），只能人工排查，浪费数小时。

## 做了什么

新 skill **`dsh-web-doctor`**（out-of-band）：

- **`scripts/doctor.sh`**：`[--fix] [--restart]` 三档
  - 诊断：web 健康 / launcher 链 / 扩展 relink 缺失 / 槽可启动性 / session 存储（check-all-sessions）/ web.log 尾部 / 最近会话"最后发生的事"
  - `--fix`：relink 自愈（ab.sh status）→ bin/dsh 补位 → 未知事件 ignorable 标记（repair-unknown-events）→ 损坏日志修复 → **verify 重查**
  - `--restart`：restart-dsh-web.sh 拉起 + 轮询 200（web 已 200 则跳过，不误杀会话）
  - **out-of-band 构造**：只用本机工具（node/zstd/jq/curl/ps/lsof）+ 已装 skills 脚本，零 web 依赖
- **`scripts/session-last-activity.mjs`**：最近活跃会话的尾部事件（类型/seq/时间/内容提示）——"挂之前系统在做什么"
- **`SKILL.md`**：触发说明 + 自愈 prompt 模板（web 恢复后接续排查）
- README（双语）组件表 + 能力地图 + `install.sh` 纳入新 skill

## 验收（实测）

- 故障注入（删 dsh-llm relink + 删 bin/dsh）→ doctor 诊断**同时报出两个问题**
- `doctor.sh --fix` → 重建 relink + 补 bin/dsh → verify 全绿 → report "no problems found"
- `doctor.sh --fix --restart`（web 健康）→ 诊断/修复正常，restart 段正确跳过（不杀会话）
- `bash -n` / `node --check` 全过

## 使用

```sh
bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh --fix --restart   # 一键救火
```
