### PR TITLE
feat(web-doctor): minimal-dependency layers — L0 self-contained, L1 degrades

### DIFF
--- a/skills/dsh-web-doctor/SKILL.md
+++ b/skills/dsh-web-doctor/SKILL.md
@@ -57,10 +57,24 @@ bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh --fix --restart  # 诊断 + 
 3. **扩展 relink**：ab-config 里每个 `extensions[].relink` 是否存在（缺失 = 未来 `dsh web`
    必挂，正是 2026-08-11 事故）。
 4. **槽可启动**：current 有 `bin/dsh` 或编译产物 `apps/cli/lib/bin.js`。
-5. **session 存储**：全量 `check-all-sessions.mjs`（92 会话示例：全过）。
+5. **session 存储（L0 文件层）**：`session-store-check.mjs` 逐日志校验可解压、header 正确、
+   尾部合法 JSON——**只用 node 标准库 + zstd CLI，不加载任何 DSH 编译包**。
 6. **web.log 尾部**：最近启动失败的直接证据。
 7. **最近会话"最后发生的事"**：`session-last-activity.mjs` 列最近活跃会话的最后事件
    （类型/seq/时间/内容提示）——"挂了之前系统在做什么"。
+
+## 依赖分层（极小依赖设计）
+
+doctor 是**最后一道防线**，它自己不能依赖"可能已经被弄坏的东西"（current 槽的编译产物、
+扩展 bundle）。分两层：
+
+| 层 | 依赖 | 覆盖 | 失败影响 |
+|---|---|---|---|
+| **L0（自包含）** | 系统工具（node 内置/zstd CLI/jq/curl/ps/lsof）+ 纯文件操作 | 布局快照、web 健康、launcher 链、relink 存在性、槽可启动、**session 文件层检查**、最近活动、relink/launcher 修复、**内置 restart 兜底** | **永不因自身依赖失败**——即使 current 槽的编译产物整个没了也能跑 |
+| **L1（深度，可降级）** | current 槽编译产物（`@deepseek-ai/dsh-session-persistence-jsonl` 等） | `check-all-sessions` 全量读取校验、`repair-unknown-events` ignorable 修复 | 加载失败 → 明确报告"deep check unavailable（current slot 可能坏了）"，L0 结论仍权威，doctor 继续 |
+
+**设计契约**：doctor 的 L0 路径**绝不 import 任何 `@deepseek-ai/*` 编译包、绝不加载扩展插件**。
+L1 只是增强，加载不了就降级——救火工具必须在自己要修的故障里也活着。
 
 ## 自愈 prompt（web 恢复后 / 给其它 agent）
 

--- a/skills/dsh-web-doctor/scripts/doctor.sh
+++ b/skills/dsh-web-doctor/scripts/doctor.sh
@@ -6,11 +6,24 @@
 # entirely from the terminal with local tools (node/zstd/jq/curl/ps/lsof) and
 # the installed skills' scripts; it does NOT depend on a running web process.
 #
+# DEPENDENCY LAYERS (minimal-dependency by design — the doctor must keep
+# working when the things it would fix are broken):
+#   L0 (self-contained, never fails on its own): system tools + node built-ins
+#      + zstd CLI + plain file ops. Covers: layout snapshot, web health,
+#      launcher chain, extension relink existence, slot bootability, session
+#      FILE-layer check (session-store-check.mjs), last-activity, relink +
+#      launcher repair, built-in restart fallback. No DSH compiled package and
+#      no extension bundle is ever loaded by L0.
+#   L1 (deep, degrades gracefully): compiled-reader checks and repairs
+#      (check-all-sessions, repair-unknown-events). These need the current
+#      slot's compiled packages; if they cannot load, the doctor reports that
+#      explicitly and keeps going — L0 conclusions stay authoritative.
+#
 # What it does, in order:
 #   1. environment + layout snapshot (current slot, ab-state, web, launcher)
 #   2. diagnosis: web health, launcher chain, extension relinks, slot bootable,
-#      session store health, web.log tail, and "what happened last" in the most
-#      recently active sessions
+#      session store health (L0 file layer + optional L1 deep), web.log tail,
+#      and "what happened last" in the most recently active sessions
 #   3. --fix: apply known self-heals (relink recreate, slot launcher, unknown
 #      session-event ignorable marking, corrupt-log repair)
 #   4. --restart: relaunch dsh web and poll HTTP 200
@@ -143,11 +156,16 @@ if [ -n "$CURRENT" ]; then
   fi
 fi
 
-# 3e. session store health (lightweight: check-all-sessions)
+# 3e. session store health — L0 self-contained check FIRST (file layer only:
+# node built-ins + zstd CLI, no DSH compiled packages — works even when the
+# current slot / its build artifacts are broken). The compiled-reader deep
+# check (check-all-sessions) is an OPTIONAL enhancement that runs only when
+# it can load; its failure must never fail the doctor.
 echo
-say "== session store =="
-if [ -f "$REC/check-all-sessions.mjs" ]; then
-  out=$(node "$REC/check-all-sessions.mjs" 2>&1)
+say "== session store (file-layer, minimal deps) =="
+L0="$SKILLS_DIR/dsh-web-doctor/scripts/session-store-check.mjs"
+if [ -f "$L0" ]; then
+  out=$(node "$L0" 2>&1)
   rc=$?
   tail_line=$(printf '%s\n' "$out" | tail -1)
   if [ "$rc" = "0" ]; then
@@ -157,8 +175,16 @@ if [ -f "$REC/check-all-sessions.mjs" ]; then
     note_problem
   fi
 else
-  err "check-all-sessions.mjs missing — session store not checked"
+  err "session-store-check.mjs missing — session store not checked"
   note_problem
+fi
+if [ -f "$REC/check-all-sessions.mjs" ]; then
+  deep=$(node "$REC/check-all-sessions.mjs" 2>&1); drc=$?
+  if [ "$drc" = "0" ]; then
+    say "  deep check (compiled reader): $(printf '%s\n' "$deep" | tail -1)"
+  else
+    warn "  deep check unavailable (compiled reader failed to load — current slot may be broken; file-layer check above is authoritative for doctor's purposes)"
+  fi
 fi
 
 # 3f. web.log tail
@@ -213,7 +239,9 @@ LAUNCHER
     ok "materialized $CURRENT/bin/dsh (compiled CLI entry)"
   fi
 
-  # 4c. unknown session-event repair (ignorable marking)
+  # 4c. unknown session-event repair (ignorable marking) — DEEP layer: needs the
+  #     compiled DSH reader, so it may not load when the slot is broken. That
+  #     failure must degrade gracefully, not fail the doctor.
   if [ -f "$REC/repair-unknown-events.mjs" ]; then
     node "$REC/repair-unknown-events.mjs" --all >/tmp/dsh-doctor-repair.log 2>&1
     rc=$?
@@ -221,7 +249,8 @@ LAUNCHER
       tail -1 /tmp/dsh-doctor-repair.log | sed 's/^/  /'
       ok "unknown-event repair pass complete"
     else
-      err "unknown-event repair failed (see /tmp/dsh-doctor-repair.log)"
+      err "unknown-event repair could not run (deep layer needs the compiled DSH reader; likely the current slot is broken)."
+      err "  diagnose the slot first; the repair itself: node $REC/repair-unknown-events.mjs --all"
       note_problem
     fi
   fi
@@ -259,15 +288,26 @@ PY
   fi
 fi
 
-# --- 5. restart --------------------------------------------------------------
+# --- 5. restart (L0: self-contained kill + nohup + poll; the recovery skill's
+#        restart script is used when present, else doctor does it itself —
+#        the relaunch must never depend on a skill that may not be installed) --
 if [ "$FLAG_RESTART" = "1" ]; then
   echo
   info "== relaunching dsh web (port $PORT) =="
   code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
   if [ "$code" = "200" ]; then
     ok "web already up — skipping restart"
-  elif [ -f "$REC/restart-dsh-web.sh" ]; then
-    sh "$REC/restart-dsh-web.sh" 2>&1 | tail -6
+  else
+    if [ -f "$REC/restart-dsh-web.sh" ]; then
+      sh "$REC/restart-dsh-web.sh" >/tmp/dsh-doctor-restart.log 2>&1
+      say "  restart script: $(tail -2 /tmp/dsh-doctor-restart.log | tr '\n' ' ')"
+    else
+      say "  restarting with doctor's built-in fallback (no recovery skill present)..."
+      local_pids=$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null)
+      [ -n "$local_pids" ] && kill -TERM $local_pids 2>/dev/null || true
+      i=0; while [ "$i" -lt 30 ] && lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; do i=$((i+1)); sleep 1; done
+      ( cd "$HOME" && nohup dsh web >/tmp/dsh-web-restart.log 2>&1 & )
+    fi
     code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
     if [ "$code" = "200" ]; then
       ok "web is UP on :$PORT after restart"
@@ -275,9 +315,6 @@ if [ "$FLAG_RESTART" = "1" ]; then
       err "web NOT up after restart (HTTP $code) — inspect the log tail above"
       exit 2
     fi
-  else
-    err "restart-dsh-web.sh missing — cannot relaunch"
-    exit 2
   fi
 fi
 

--- a/skills/dsh-web-doctor/scripts/session-store-check.mjs
+++ b/skills/dsh-web-doctor/scripts/session-store-check.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * session-store-check.mjs — MINIMAL-dependency session store health check.
+ *
+ * Out-of-band and dependency-light BY DESIGN: uses only node built-ins plus
+ * the `zstd` CLI. It does NOT load any DSH compiled package (no
+ * @deepseek-ai/dsh-session-persistence-jsonl, no cordis, no extension
+ * bundle), so it keeps working when the current slot or its build artifacts
+ * are broken — exactly the situation dsh-web-doctor exists for. It checks
+ * the FILE layer: every log decodes, its first row is a session header, and
+ * its last row parses as JSON. (Full event-vocabulary / seq-continuity
+ * checks need the compiled reader; that is the doctor's optional deep layer.)
+ *
+ * Usage:
+ *   node session-store-check.mjs [--root <sessions-root>]
+ * Exit 0 when every log is file-healthy, 1 when any is not.
+ */
+import { parseArgs } from 'node:util'
+import { readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { execFileSync } from 'node:child_process'
+
+const { values } = parseArgs({ options: { root: { type: 'string' } } })
+const root = values.root ?? join(homedir(), '.dsh', 'sessions')
+
+function listLogs() {
+  const out = []
+  let projects
+  try { projects = readdirSync(root, { withFileTypes: true }) } catch { return out }
+  for (const p of projects) {
+    if (!p.isDirectory()) continue
+    const pdir = join(root, p.name)
+    for (const s of readdirSync(pdir, { withFileTypes: true })) {
+      if (!s.isDirectory()) continue
+      const log = join(pdir, s.name, 'session.jsonl.zstd')
+      try { statSync(log); out.push({ id: s.name, log }) } catch { /* skip */ }
+    }
+  }
+  return out
+}
+
+function checkLog(log) {
+  let plain
+  try {
+    plain = execFileSync('zstd', ['-dc', log], { maxBuffer: 1024 * 1024 * 1024 })
+  } catch (e) {
+    return `cannot decode: ${String(e.stderr || e.message).split('\n')[0]}`
+  }
+  const text = plain.toString('utf8')
+  const lines = text.trimEnd().split('\n')
+  if (lines.length === 0) return 'empty log'
+  let header
+  try { header = JSON.parse(lines[0]) } catch { return 'first row is not JSON' }
+  if (header.type !== 'session' || typeof header.id !== 'string') return 'first row is not a session header'
+  let last
+  try { last = JSON.parse(lines[lines.length - 1]) } catch { return 'last row is not JSON (torn tail)' }
+  if (typeof last.type !== 'string') return 'last row has no type'
+  return null
+}
+
+const logs = listLogs()
+let ok = 0
+const fails = []
+for (const l of logs) {
+  const problem = checkLog(l.log)
+  if (problem) fails.push({ id: l.id, problem })
+  else ok++
+}
+for (const f of fails) console.log(`FAIL ${f.id}: ${f.problem}`)
+console.log(`RESULT: ${ok} pass, ${fails.length} fail (of ${logs.length} zstd logs)`)
+process.exit(fails.length > 0 ? 1 : 0)


### PR DESCRIPTION
The doctor must keep working when the things it would fix are broken: it must not depend on the current slot's compiled packages or any extension bundle to START and fix the basics.

- New `session-store-check.mjs`: L0 session FILE-layer check — node built-ins + zstd CLI only, zero @deepseek-ai/* compiled imports. Authoritative for doctor's purposes; 92/92 on the live store.
- doctor.sh dependency layers: L0 self-contained (layout, web health, launcher chain, relink existence, slot bootability, session file-layer, last-activity, relink+launcher repair, built-in restart fallback) / L1 deep (check-all-sessions, repair-unknown-events) that degrades with an explicit message when the compiled reader cannot load.
- Verified live: with the compiled session-persistence lib hidden (simulated broken slot), L0 still reports 92/92 and deep check degrades cleanly; web/relink/launcher checks unaffected.
- SKILL.md documents the dependency-layer contract.