### PR TITLE
feat(web-doctor): LLM brain via --agent (headless one-shot self-heal)

### DIFF
--- a/skills/dsh-web-doctor/SKILL.md
+++ b/skills/dsh-web-doctor/SKILL.md
@@ -3,7 +3,8 @@ name: dsh-web-doctor
 description: >-
   dsh web 挂了/A/B 双槽都起不来时的 out-of-band 医生：不依赖 web 进程，纯终端一键诊断
   （web 健康、launcher 链、扩展 relink、槽可启动性、session 存储、web.log、最近会话最后发生的事）
-  → 自动修复（relink 自愈、bin/dsh 补位、未知事件 ignorable、损坏日志修复）→ 把 web 拉回来并验证。
+  → 确定性自动修复（relink 自愈、bin/dsh 补位、未知事件 ignorable、损坏日志修复）→ 把 web 拉回来并验证；
+  或 --agent 模式交给 headless LLM agent（读报告+日志推理根因、自适应修复、验证），应对 DSH 改版与新故障模式。
   当用户说"web 挂了怎么查"、"dsh web 起不来"、"3080 挂了"、"怎么自愈"、"跑一下 doctor"、
   "看看系统为什么挂了"时使用，即使 GUI/agent 都不可用（在终端跑 dsh-doctor（或 bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh））。
   English: out-of-band doctor for dsh web when it is down or won't boot (both A/B slots
@@ -42,9 +43,10 @@ skills 的脚本，**不依赖任何 web 进程**。
 直接在终端敲**：
 
 ```sh
-dsh-doctor                    # 只诊断（只读）
-dsh-doctor --fix              # 诊断 + 自动修复
+dsh-doctor                    # 只诊断（只读，秒级）
+dsh-doctor --fix              # 诊断 + 确定性自动修复（保底，不依赖 LLM）
 dsh-doctor --fix --restart    # 诊断 + 修复 + 拉起 web（救火一条龙）
+dsh-doctor --agent            # LLM 主脑：体检 → 交给 headless LLM agent 找根因/修复/拉回
 ```
 
 底层脚本在 `~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh`（也可直接 `bash` 它），
@@ -53,8 +55,21 @@ dsh-doctor --fix --restart    # 诊断 + 修复 + 拉起 web（救火一条龙�
 | Flag | 作用 |
 |---|---|
 | （无） | 只读诊断，报告问题清单（exit 0 全好 / exit 1 有问题） |
-| `--fix` | 自动修复：relink 自愈 → bin/dsh 补位 → 会话未知事件 ignorable → 损坏日志修复 → **verify 重查** |
+| `--fix` | 确定性自动修复：relink 自愈 → bin/dsh 补位 → 会话未知事件 ignorable → 损坏日志修复 → **verify 重查**（不依赖 LLM） |
 | `--restart` | 修复后拉起 web（kill 旧 + nohup 重启 + 轮询 HTTP 200）；web 已 200 则跳过 |
+| `--agent` | **LLM 主脑**：体检报告 tee 到 `/tmp/dsh-doctor-report.txt` → `dsh --profile headless` 起 one-shot LLM agent（内置自愈 prompt）→ 读报告+日志推理根因 → 用确定性原语（或直接命令）修复 → 验证 200 → 输出结论 |
+
+## 分层：确定性是"手和眼"，LLM 是"大脑"
+
+| 层 | 什么 | 为什么需要 |
+|---|---|---|
+| **L0/L1 确定性**（`--fix`） | 检查原语（curl/readlink/文件存在性/zstd+JSONL）+ 修复原语（ln -sfn/写包装器/restart） | 秒级、零 LLM 成本、web 挂得再彻底也能跑；给 LLM 提供**可靠的事实和可执行动作** |
+| **LLM 主脑**（`--agent`） | headless one-shot agent：读报告/session 尾部/web.log → 推理根因 → 决策修复 → 验证 | **适应未知与新版本**：DSH 改版、新故障模式，确定性规则想不到——LLM 读新症状自己推理（实测：它识别出 web.log 的 `node: not found` 是 8/10 历史残留而非当前故障） |
+
+**为什么不能只有确定性**：写死的规则（产物路径、错误形态、配置格式）会随 DSH 改版失效
+（0811 就删过 `bin/dsh`）；新故障模式规则想不到。
+**为什么不能只有 LLM**：web 挂时 agent 起不来（headless 也依赖 harness 本身）；让 LLM 扫 92 个
+session 太慢太贵；修复需要不变的操作原语。**确定性传感器 + LLM 大脑是正解。**
 
 ## 诊断项（doctor 查什么）
 
@@ -84,11 +99,12 @@ L1 只是增强，加载不了就降级——救火工具必须在自己要修�
 
 ## 自愈 prompt（web 恢复后 / 给其它 agent）
 
-用户（或任何可用 agent）把下面这段粘给恢复后的会话，即可接续排查：
+`dsh-doctor --agent` 已内置完整自愈 prompt 并自动调 headless LLM。以下文本用于**没有
+headless**（或想手动把上下文交给 web 恢复后的会话）时：
 
 ```text
-dsh web 之前挂了，已跑 doctor.sh 自愈。请：
-1. 看 doctor 报告：dsh-doctor
+dsh web 之前挂了，已跑 dsh-doctor 自愈。请：
+1. 看 doctor 报告：dsh-doctor（或 /tmp/dsh-doctor-report.txt）
 2. 若还有残留问题：读 ~/.dsh/skills/dsh-session-recovery/SKILL.md（会话问题）和
    ~/.dsh/skills/dsh-snapshot-ab/SKILL.md（A/B 切换问题）
 3. 用 session-last-activity 看挂之前的最后操作，定位人为/外部原因

--- a/skills/dsh-web-doctor/scripts/doctor.sh
+++ b/skills/dsh-web-doctor/scripts/doctor.sh
@@ -46,15 +46,26 @@ AB="$SKILLS_DIR/dsh-snapshot-ab/scripts/ab.sh"
 REC="$SKILLS_DIR/dsh-session-recovery/scripts"
 PORT="${DSH_WEB_PORT:-3080}"
 
-FLAG_FIX=0; FLAG_RESTART=0; FLAG_QUIET=0
+FLAG_FIX=0; FLAG_RESTART=0; FLAG_QUIET=0; FLAG_AGENT=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --fix) FLAG_FIX=1; shift ;;
     --restart) FLAG_RESTART=1; shift ;;
+    --agent) FLAG_AGENT=1; shift ;;
     --quiet) FLAG_QUIET=1; shift ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+# --agent: the LLM is the doctor's brain. Tee every deterministic check to a
+# report file, then hand it to a one-shot headless agent (dsh --profile
+# headless) together with the self-heal prompt — the LLM reads the report,
+# reasons about the root cause (adapting to whatever changed in DSH), fixes
+# via the deterministic primitives (or direct commands), and relaunches web.
+REPORT="${DSH_DOCTOR_REPORT:-/tmp/dsh-doctor-report.txt}"
+if [ "$FLAG_AGENT" = "1" ]; then
+  exec > >(tee "$REPORT") 2>&1
+fi
 
 say()  { [ "$FLAG_QUIET" = "1" ] || printf '%s\n' "$*"; }
 warn() { printf '\033[1;33m[doctor]\033[0m %s\n' "$*" >&2; }
@@ -316,6 +327,51 @@ if [ "$FLAG_RESTART" = "1" ]; then
       exit 2
     fi
   fi
+fi
+
+# --- 5b. LLM brain (--agent): hand the deterministic report to a one-shot
+#        headless agent. The LLM reasons over the report + last activity +
+#        logs, picks (and adapts) the fix, executes it, and verifies. This is
+#        the resilient layer: deterministic rules can't anticipate a changed
+#        DSH, an LLM can read the new symptoms and reason its way out.
+if [ "$FLAG_AGENT" = "1" ]; then
+  echo
+  info "== LLM brain: handing the report to a one-shot headless agent =="
+  if ! command -v dsh >/dev/null 2>&1; then
+    err "'dsh' not on PATH — cannot launch the headless agent (fall back to: dsh-doctor --fix --restart)"
+    exit 1
+  fi
+  if ! dsh --profile headless --help >/dev/null 2>&1; then
+    err "'dsh --profile headless' unavailable — LLM brain cannot start (fall back to: dsh-doctor --fix --restart)"
+    exit 1
+  fi
+  AGENT_TASK=$(cat <<'PROMPT'
+你是 dsh web 的 out-of-band 自愈 agent（one-shot）。web（3080）挂了或状态异常，
+由你诊断根因、修复、把 web 拉回来。headless 模式下你可用工具读文件/执行命令。
+
+步骤：
+1. 读 /tmp/dsh-doctor-report.txt —— dsh-doctor 的确定性体检报告
+   （web/launcher/relink/槽可启动/session 文件层/web.log 尾部/最近活动）。
+2. 读 ~/.dsh/skills/dsh-web-doctor/SKILL.md —— 可用修复原语说明。
+3. 需要更深入时：node ~/.dsh/skills/dsh-web-doctor/scripts/session-last-activity.mjs
+   看最近会话最后发生的事；tail ~/.dsh/source/web.log。
+4. 找根因 → 修复。优先复用确定性原语：
+   bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh --fix
+   （relink 自愈 / bin/dsh 补位 / 未知事件 ignorable / 损坏日志修复）；
+   也可直接执行修复命令（如 ln -sfn 重建扩展链接）。
+5. 验证：curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3080/ 应为 200；
+   若 web 未起，用 restart-dsh-web.sh 或 nohup dsh web 拉起。
+6. 最终输出（简洁中文）：根因一句话、做了什么、当前 web 状态；
+   若无法修复：卡在哪一步、缺什么、需要用户做什么。
+
+约束：你是自愈 agent，web/GUI 可能不可用；只做必要修复，不动用户数据；
+不确定的操作先读报告/日志再决定。不要臆造；查不到就明说。
+PROMPT
+)
+  ok "launching: dsh --profile headless <self-heal task> (report: $REPORT)"
+  dsh --profile headless "$AGENT_TASK" 2>&1 | sed 's/^/  [agent] /'
+  echo
+  info "LLM brain finished — verify with: dsh-doctor  (or curl http://127.0.0.1:3080/)"
 fi
 
 # --- 6. report ---------------------------------------------------------------


### PR DESCRIPTION
The doctor was deterministic-only; the user's intent was LLM-driven self-healing. Deterministic rules can't anticipate a changed DSH (0811 deleted bin/dsh) or new failure modes — an LLM reads the new symptoms and reasons its way out.

- `doctor.sh --agent`: tees the deterministic report to /tmp/dsh-doctor-report.txt, then launches `dsh --profile headless` (one-shot LLM agent) with a built-in self-heal prompt (read report + SKILL.md + last-activity + web.log → reason root cause → fix via deterministic primitives or direct commands → verify 200 → report).
- Verified live: LLM correctly identified web.log 'node: not found' as 8/10 history, not a current fault; made no unnecessary changes.
- SKILL.md documents the layered model: deterministic = sensors/actuators (reliable, cheap, run when everything is broken); LLM = brain (adapts to DSH changes). --fix remains the no-LLM fallback.