### PR TITLE
feat(web-doctor): interactive menu — dsh-doctor with no args shows the options

### DIFF
--- a/skills/dsh-web-doctor/SKILL.md
+++ b/skills/dsh-web-doctor/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   → 确定性自动修复（relink 自愈、bin/dsh 补位、未知事件 ignorable、损坏日志修复）→ 把 web 拉回来并验证；
   或 --agent 模式交给 headless LLM agent（读报告+日志推理根因、自适应修复、验证），应对 DSH 改版与新故障模式。
   当用户说"web 挂了怎么查"、"dsh web 起不来"、"3080 挂了"、"怎么自愈"、"跑一下 doctor"、
-  "看看系统为什么挂了"时使用，即使 GUI/agent 都不可用（在终端跑 dsh-doctor（或 bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh））。
+  "看看系统为什么挂了"时使用，即使 GUI/agent 都不可用（终端跑 dsh-doctor，无参数即交互菜单：体检/LLM 自愈/确定性修复+拉起）。
   English: out-of-band doctor for dsh web when it is down or won't boot (both A/B slots
   broken, GUI/agent unavailable). One terminal command diagnoses (web health, launcher
   chain, extension relinks, slot bootability, session store, web.log, last activity in
@@ -37,16 +37,35 @@ skills 的脚本，**不依赖任何 web 进程**。
 - **web 挂时 agent 也不可用**（agent 由 web 托管）——直接让用户在终端跑 doctor.sh，或把
   本 skill 的自愈 prompt 粘给任何可用的 agent。
 
-## 用法（用户角度：一条短命令）
+## 用法（用户角度：一条短命令，无参数即交互菜单）
 
-装好（`install.sh`）后，`dsh-doctor` 就在 PATH 上（`~/.local/bin/dsh-doctor`），**web 挂的时候
-直接在终端敲**：
+装好（`install.sh`）后，`dsh-doctor` 就在 PATH 上（`~/.local/bin/dsh-doctor`）。**web 挂的时候
+直接在终端敲 `dsh-doctor`，不用记任何参数**——它会显示一个菜单：
+
+```
+==============================================================
+  dsh web Doctor — 一键救火
+  当前 web(:3080): ✅ 正常 / ❌ 异常·未起
+==============================================================
+  1) 快速体检（只读，几秒）        — 看系统哪里有问题
+  2) LLM 智能自愈（推荐）          — 自动诊断+找根因+修复+拉起 web
+  3) 确定性修复+拉起（不依赖 LLM） — 规则保底，web 挂得再彻底也能跑
+  4) 退出
+  选择 [1-4]:
+```
+
+- 不确定选什么 → **选 2**（LLM 智能自愈，推荐）
+- 想先看看情况 → **选 1**；web 起不来且没 LLM → **选 3**
+- 菜单每次跑完回到菜单，按 `4` 退出
+
+**参数模式**（脚本/自动化/高级用，等价于菜单项；普通用户不需要）：
 
 ```sh
-dsh-doctor                    # 只诊断（只读，秒级）
-dsh-doctor --fix              # 诊断 + 确定性自动修复（保底，不依赖 LLM）
-dsh-doctor --fix --restart    # 诊断 + 修复 + 拉起 web（救火一条龙）
-dsh-doctor --agent            # LLM 主脑：体检 → 交给 headless LLM agent 找根因/修复/拉回
+dsh-doctor                    # 交互菜单（终端下）；脚本/管道下 = 只读诊断
+dsh-doctor --agent            # = 菜单 2（LLM 主脑）
+dsh-doctor --fix --restart    # = 菜单 3（确定性修复 + 拉起）
+dsh-doctor --fix              # 只确定性修复，不拉起
+dsh-doctor --quiet            # 少输出
 ```
 
 底层脚本在 `~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh`（也可直接 `bash` 它），
@@ -54,10 +73,10 @@ dsh-doctor --agent            # LLM 主脑：体检 → 交给 headless LLM agen
 
 | Flag | 作用 |
 |---|---|
-| （无） | 只读诊断，报告问题清单（exit 0 全好 / exit 1 有问题） |
+| （无） | 交互菜单（终端）；管道/脚本下退化为只读诊断 |
+| `--agent` | **LLM 主脑**：体检报告 tee 到 `/tmp/dsh-doctor-report.txt` → `dsh --profile headless` 起 one-shot LLM agent（内置自愈 prompt）→ 读报告+日志推理根因 → 用确定性原语（或直接命令）修复 → 验证 200 → 输出结论 |
 | `--fix` | 确定性自动修复：relink 自愈 → bin/dsh 补位 → 会话未知事件 ignorable → 损坏日志修复 → **verify 重查**（不依赖 LLM） |
 | `--restart` | 修复后拉起 web（kill 旧 + nohup 重启 + 轮询 HTTP 200）；web 已 200 则跳过 |
-| `--agent` | **LLM 主脑**：体检报告 tee 到 `/tmp/dsh-doctor-report.txt` → `dsh --profile headless` 起 one-shot LLM agent（内置自愈 prompt）→ 读报告+日志推理根因 → 用确定性原语（或直接命令）修复 → 验证 200 → 输出结论 |
 
 ## 分层：确定性是"手和眼"，LLM 是"大脑"
 
@@ -70,6 +89,24 @@ dsh-doctor --agent            # LLM 主脑：体检 → 交给 headless LLM agen
 （0811 就删过 `bin/dsh`）；新故障模式规则想不到。
 **为什么不能只有 LLM**：web 挂时 agent 起不来（headless 也依赖 harness 本身）；让 LLM 扫 92 个
 session 太慢太贵；修复需要不变的操作原语。**确定性传感器 + LLM 大脑是正解。**
+
+### headless 依赖面（--agent 的可用边界，实测确认 2026-08-11）
+
+`dsh --profile headless` 的插件组合 = `dsh-base` + `dsh-headless` 两个 bundle，**不加载
+dsh-track 等 web 专属扩展**（web profile 才挂 dsh-track/dsh-restart-recover）。它自带
+skill provider（`dsh-skill*`，扫描 `~/.dsh/skills`）和完整 agent 栈（agent-loop/llm/
+bash-sandbox/fs-policy/commands）。
+
+| 依赖面 | headless（--agent） | doctor 确定性（--fix） |
+|---|---|---|
+| 扩展 bundle（dsh-track 等） | **不加载** → 扩展链接故障不影响它 | 不加载 |
+| skills（~/.dsh/skills） | **加载**（skill-local provider） | 直接读文件 |
+| current 槽编译产物 | **依赖**（跑在槽上） | 不依赖（L0） |
+| LLM 凭据 | **依赖** | 不需要 |
+
+**边界结论**：扩展依赖故障（如 dsh-llm 链接被清）→ `--agent` 的 LLM 照样能上（headless 不
+加载扩展）；**槽/编译产物坏或 LLM 凭据缺失** → headless 起不来 → 用菜单 3 / `--fix --restart`
+（L0 不依赖槽和凭据）。
 
 ## 诊断项（doctor 查什么）
 

--- a/skills/dsh-web-doctor/scripts/doctor.sh
+++ b/skills/dsh-web-doctor/scripts/doctor.sh
@@ -6,6 +6,17 @@
 # entirely from the terminal with local tools (node/zstd/jq/curl/ps/lsof) and
 # the installed skills' scripts; it does NOT depend on a running web process.
 #
+# USER-FIRST: run `dsh-doctor` with NO arguments → an interactive menu shows
+# the web status and the three things you can do. No flags to remember:
+#   1. quick check (read-only)     2. LLM self-heal (recommended)
+#   3. deterministic fix + relaunch (no LLM)     4. exit
+# Flag mode (for scripts / advanced use) is unchanged:
+#   doctor.sh                 # diagnose only (read-only)
+#   doctor.sh --fix           # diagnose + deterministic auto-fix
+#   doctor.sh --fix --restart # diagnose + fix + relaunch web
+#   doctor.sh --agent         # diagnose + LLM brain (headless one-shot)
+#   doctor.sh --quiet         # less chatter
+#
 # DEPENDENCY LAYERS (minimal-dependency by design — the doctor must keep
 # working when the things it would fix are broken):
 #   L0 (self-contained, never fails on its own): system tools + node built-ins
@@ -18,22 +29,13 @@
 #      (check-all-sessions, repair-unknown-events). These need the current
 #      slot's compiled packages; if they cannot load, the doctor reports that
 #      explicitly and keeps going — L0 conclusions stay authoritative.
-#
-# What it does, in order:
-#   1. environment + layout snapshot (current slot, ab-state, web, launcher)
-#   2. diagnosis: web health, launcher chain, extension relinks, slot bootable,
-#      session store health (L0 file layer + optional L1 deep), web.log tail,
-#      and "what happened last" in the most recently active sessions
-#   3. --fix: apply known self-heals (relink recreate, slot launcher, unknown
-#      session-event ignorable marking, corrupt-log repair)
-#   4. --restart: relaunch dsh web and poll HTTP 200
-#   5. report: what was found, what was fixed, what still needs a human
-#
-# Usage:
-#   doctor.sh                 # diagnose only (read-only)
-#   doctor.sh --fix           # diagnose + auto-fix known issues
-#   doctor.sh --fix --restart # diagnose + fix + relaunch web
-#   doctor.sh --quiet         # less chatter
+#   LLM (--agent): one-shot headless agent (dsh --profile headless) reads the
+#      deterministic report + logs, reasons the root cause (adapts to DSH
+#      changes), fixes, and relaunches. Headless does NOT load the web's
+#      extension bundles (dsh-track etc. are web-profile only), so extension
+#      dependency faults do not stop the LLM brain; it DOES load skills
+#      (~/.dsh/skills) and depends on the current slot's compiled packages
+#      and LLM credentials — when those are broken, --fix (L0) is the fallback.
 #
 # Exit codes: 0 all-clear (or fixed+up); 1 diagnosis found problems;
 # 2 web not up after restart. Safe to re-run; every fix is reversible and
@@ -45,6 +47,7 @@ DSH_SOURCE="${DSH_SOURCE:-$HOME/.dsh/source}"
 AB="$SKILLS_DIR/dsh-snapshot-ab/scripts/ab.sh"
 REC="$SKILLS_DIR/dsh-session-recovery/scripts"
 PORT="${DSH_WEB_PORT:-3080}"
+REPORT="${DSH_DOCTOR_REPORT:-/tmp/dsh-doctor-report.txt}"
 
 FLAG_FIX=0; FLAG_RESTART=0; FLAG_QUIET=0; FLAG_AGENT=0
 while [ $# -gt 0 ]; do
@@ -57,16 +60,6 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# --agent: the LLM is the doctor's brain. Tee every deterministic check to a
-# report file, then hand it to a one-shot headless agent (dsh --profile
-# headless) together with the self-heal prompt — the LLM reads the report,
-# reasons about the root cause (adapting to whatever changed in DSH), fixes
-# via the deterministic primitives (or direct commands), and relaunches web.
-REPORT="${DSH_DOCTOR_REPORT:-/tmp/dsh-doctor-report.txt}"
-if [ "$FLAG_AGENT" = "1" ]; then
-  exec > >(tee "$REPORT") 2>&1
-fi
-
 say()  { [ "$FLAG_QUIET" = "1" ] || printf '%s\n' "$*"; }
 warn() { printf '\033[1;33m[doctor]\033[0m %s\n' "$*" >&2; }
 err()  { printf '\033[1;31m[doctor]\033[0m %s\n' "$*" >&2; }
@@ -76,68 +69,72 @@ info() { printf '\033[1;34m[doctor]\033[0m %s\n' "$*"; }
 PROBLEMS=0
 note_problem() { PROBLEMS=$((PROBLEMS + 1)); }
 
-# --- 1. environment ----------------------------------------------------------
-info "dsh-web-doctor (out-of-band) — port $PORT"
-missing=""
-for t in node zstd jq curl ps lsof; do
-  command -v "$t" >/dev/null 2>&1 || missing="$missing $t"
-done
-if [ -n "$missing" ]; then
-  err "missing required tools:$missing — doctor cannot run"
-  exit 2
-fi
+# ---------------------------------------------------------------------------
+# doctor_run — one pass: environment → layout → diagnosis → (fix) → (restart)
+# → (agent) → report. Flags decide which stages run.
+# ---------------------------------------------------------------------------
+doctor_run() {
+  # --- 1. environment --------------------------------------------------------
+  info "dsh-web-doctor (out-of-band) — port $PORT"
+  missing=""
+  for t in node zstd jq curl ps lsof; do
+    command -v "$t" >/dev/null 2>&1 || missing="$missing $t"
+  done
+  if [ -n "$missing" ]; then
+    err "missing required tools:$missing — doctor cannot run"
+    exit 2
+  fi
 
-# --- 2. layout snapshot ------------------------------------------------------
-CURRENT="<none>"
-[ -L "$DSH_SOURCE/current" ] && CURRENT=$(readlink "$DSH_SOURCE/current")
-info "current: $CURRENT"
-if [ -f "$DSH_SOURCE/ab-state.json" ]; then
-  python3 - "$DSH_SOURCE/ab-state.json" <<'PY' | while IFS= read -r line; do say "$line"; done
+  # --- 2. layout snapshot ----------------------------------------------------
+  CURRENT="<none>"
+  [ -L "$DSH_SOURCE/current" ] && CURRENT=$(readlink "$DSH_SOURCE/current")
+  info "current: $CURRENT"
+  if [ -f "$DSH_SOURCE/ab-state.json" ]; then
+    python3 - "$DSH_SOURCE/ab-state.json" <<'PY' | while IFS= read -r line; do say "$line"; done
 import json, sys
 d = json.load(open(sys.argv[1]))
 print(f"  phase={d.get('phase')} current-slot={d.get('current')} confirmed={d.get('confirmed')}")
 PY
-fi
-[ -n "$CURRENT" ] || { err "no current symlink — the A/B layout is missing"; note_problem; }
-
-# --- 3. diagnosis ------------------------------------------------------------
-echo
-info "== diagnosis =="
-
-# 3a. web health
-code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
-if [ "$code" = "200" ]; then
-  ok "web on :$PORT answers HTTP 200"
-else
-  err "web on :$PORT answers HTTP $code (not up)"
-  note_problem
-fi
-
-# 3b. launcher chain
-launcher=$(command -v dsh || true)
-if [ -n "$launcher" ]; then
-  resolved=$(readlink "$launcher" 2>/dev/null || echo "$launcher")
-  say "  launcher: $launcher -> $resolved"
-  # `current` is a symlink; readlink does not recurse, so accept both the
-  # real slot path and the `$DSH_SOURCE/current/...` spelling (which resolves
-  # to the current slot at exec time).
-  if [ -n "$CURRENT" ] && [[ "$resolved" != "$CURRENT/"* ]] && [[ "$resolved" != "$DSH_SOURCE/current/"* ]]; then
-    warn "launcher resolves outside current slot ($resolved)"
   fi
-  if [ -f "$launcher" ] && [ ! -x "$launcher" ]; then
-    err "launcher exists but is not executable: $launcher"
+  [ -n "$CURRENT" ] || { err "no current symlink — the A/B layout is missing"; note_problem; }
+
+  # --- 3. diagnosis ----------------------------------------------------------
+  echo
+  info "== diagnosis =="
+
+  # 3a. web health
+  code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
+  if [ "$code" = "200" ]; then
+    ok "web on :$PORT answers HTTP 200"
+  else
+    err "web on :$PORT answers HTTP $code (not up)"
     note_problem
   fi
-else
-  err "'dsh' not on PATH — launcher chain broken"
-  note_problem
-fi
 
-# 3c. extension relinks (against current)
-if [ -f "$DSH_SOURCE/ab-config.json" ]; then
-  echo
-  say "== extension relinks =="
-  python3 - "$DSH_SOURCE/ab-config.json" "$CURRENT" <<'PY' | while IFS= read -r line; do case "$line" in MISSING:*) err "${line#MISSING:}"; note_problem;; *) say "  $line";; esac; done
+  # 3b. launcher chain
+  launcher=$(command -v dsh || true)
+  if [ -n "$launcher" ]; then
+    resolved=$(readlink "$launcher" 2>/dev/null || echo "$launcher")
+    say "  launcher: $launcher -> $resolved"
+    # `current` is a symlink; readlink does not recurse, so accept both the
+    # real slot path and the `$DSH_SOURCE/current/...` spelling.
+    if [ -n "$CURRENT" ] && [[ "$resolved" != "$CURRENT/"* ]] && [[ "$resolved" != "$DSH_SOURCE/current/"* ]]; then
+      warn "launcher resolves outside current slot ($resolved)"
+    fi
+    if [ -f "$launcher" ] && [ ! -x "$launcher" ]; then
+      err "launcher exists but is not executable: $launcher"
+      note_problem
+    fi
+  else
+    err "'dsh' not on PATH — launcher chain broken"
+    note_problem
+  fi
+
+  # 3c. extension relinks (against current)
+  if [ -f "$DSH_SOURCE/ab-config.json" ]; then
+    echo
+    say "== extension relinks =="
+    python3 - "$DSH_SOURCE/ab-config.json" "$CURRENT" <<'PY' | while IFS= read -r line; do case "$line" in MISSING:*) err "${line#MISSING:}"; note_problem;; *) say "  $line";; esac; done
 import json, os, sys
 cfg, cur = sys.argv[1], sys.argv[2]
 d = json.load(open(cfg))
@@ -150,86 +147,84 @@ for ext in d.get('extensions', []):
         else:
             print(f"ok: {link} -> {rel}")
 PY
-fi
-
-# 3d. slot bootable
-if [ -n "$CURRENT" ]; then
-  echo
-  say "== current slot bootability =="
-  if [ -x "$CURRENT/bin/dsh" ]; then
-    say "  bin/dsh present"
-  elif [ -x "$CURRENT/apps/cli/lib/bin.js" ]; then
-    warn "  no bin/dsh — compiled CLI present (launcher chain may still break if bin/dsh is what ~/.local/bin/dsh resolves to)"
-    note_problem
-  else
-    err "  current slot has neither bin/dsh nor apps/cli/lib/bin.js — not bootable"
-    note_problem
   fi
-fi
 
-# 3e. session store health — L0 self-contained check FIRST (file layer only:
-# node built-ins + zstd CLI, no DSH compiled packages — works even when the
-# current slot / its build artifacts are broken). The compiled-reader deep
-# check (check-all-sessions) is an OPTIONAL enhancement that runs only when
-# it can load; its failure must never fail the doctor.
-echo
-say "== session store (file-layer, minimal deps) =="
-L0="$SKILLS_DIR/dsh-web-doctor/scripts/session-store-check.mjs"
-if [ -f "$L0" ]; then
-  out=$(node "$L0" 2>&1)
-  rc=$?
-  tail_line=$(printf '%s\n' "$out" | tail -1)
-  if [ "$rc" = "0" ]; then
-    ok "sessions: $tail_line"
-  else
-    err "sessions: $tail_line"
-    note_problem
-  fi
-else
-  err "session-store-check.mjs missing — session store not checked"
-  note_problem
-fi
-if [ -f "$REC/check-all-sessions.mjs" ]; then
-  deep=$(node "$REC/check-all-sessions.mjs" 2>&1); drc=$?
-  if [ "$drc" = "0" ]; then
-    say "  deep check (compiled reader): $(printf '%s\n' "$deep" | tail -1)"
-  else
-    warn "  deep check unavailable (compiled reader failed to load — current slot may be broken; file-layer check above is authoritative for doctor's purposes)"
-  fi
-fi
-
-# 3f. web.log tail
-if [ -f "$DSH_SOURCE/web.log" ]; then
-  echo
-  say "== web.log tail =="
-  tail -8 "$DSH_SOURCE/web.log" | sed 's/^/  /' >&2
-fi
-
-# 3g. what happened last (most recently active sessions)
-echo
-say "== last activity in recent sessions =="
-if [ -f "$SKILLS_DIR/dsh-web-doctor/scripts/session-last-activity.mjs" ]; then
-  node "$SKILLS_DIR/dsh-web-doctor/scripts/session-last-activity.mjs" --limit 4 2>&1 | sed 's/^/  /'
-fi
-
-# --- 4. repair ---------------------------------------------------------------
-if [ "$FLAG_FIX" = "1" ]; then
-  echo
-  info "== auto-fix =="
-
-  # 4a. relink + launcher self-heal via ab.sh status (idempotent, read-mostly)
-  if [ -x "$AB" ]; then
-    if "$AB" status >/dev/null 2>&1; then
-      ok "ab.sh status ran (relink self-heal active)"
+  # 3d. slot bootable
+  if [ -n "$CURRENT" ]; then
+    echo
+    say "== current slot bootability =="
+    if [ -x "$CURRENT/bin/dsh" ]; then
+      say "  bin/dsh present"
+    elif [ -x "$CURRENT/apps/cli/lib/bin.js" ]; then
+      warn "  no bin/dsh — compiled CLI present (launcher chain may still break if bin/dsh is what ~/.local/bin/dsh resolves to)"
+      note_problem
     else
-      warn "ab.sh status exited non-zero (see above)"
+      err "  current slot has neither bin/dsh nor apps/cli/lib/bin.js — not bootable"
+      note_problem
     fi
   fi
 
-  # 4b. slot launcher materialization (20260811+ slots have no bin/dsh)
-  if [ -n "$CURRENT" ] && [ ! -x "$CURRENT/bin/dsh" ] && [ -x "$CURRENT/apps/cli/lib/bin.js" ]; then
-    mkdir -p "$CURRENT/bin"
-    cat > "$CURRENT/bin/dsh" <<'LAUNCHER'
+  # 3e. session store health — L0 self-contained check FIRST (file layer only:
+  # node built-ins + zstd CLI, no DSH compiled packages — works even when the
+  # current slot / its build artifacts are broken). The compiled-reader deep
+  # check (check-all-sessions) is an OPTIONAL enhancement.
+  echo
+  say "== session store (file-layer, minimal deps) =="
+  L0="$SKILLS_DIR/dsh-web-doctor/scripts/session-store-check.mjs"
+  if [ -f "$L0" ]; then
+    out=$(node "$L0" 2>&1); rc=$?
+    tail_line=$(printf '%s\n' "$out" | tail -1)
+    if [ "$rc" = "0" ]; then
+      ok "sessions: $tail_line"
+    else
+      err "sessions: $tail_line"
+      note_problem
+    fi
+  else
+    err "session-store-check.mjs missing — session store not checked"
+    note_problem
+  fi
+  if [ -f "$REC/check-all-sessions.mjs" ]; then
+    deep=$(node "$REC/check-all-sessions.mjs" 2>&1); drc=$?
+    if [ "$drc" = "0" ]; then
+      say "  deep check (compiled reader): $(printf '%s\n' "$deep" | tail -1)"
+    else
+      warn "  deep check unavailable (compiled reader failed to load — current slot may be broken; file-layer check above is authoritative for doctor's purposes)"
+    fi
+  fi
+
+  # 3f. web.log tail
+  if [ -f "$DSH_SOURCE/web.log" ]; then
+    echo
+    say "== web.log tail =="
+    tail -8 "$DSH_SOURCE/web.log" | sed 's/^/  /' >&2
+  fi
+
+  # 3g. what happened last (most recently active sessions)
+  echo
+  say "== last activity in recent sessions =="
+  if [ -f "$SKILLS_DIR/dsh-web-doctor/scripts/session-last-activity.mjs" ]; then
+    node "$SKILLS_DIR/dsh-web-doctor/scripts/session-last-activity.mjs" --limit 4 2>&1 | sed 's/^/  /'
+  fi
+
+  # --- 4. repair ---------------------------------------------------------------
+  if [ "$FLAG_FIX" = "1" ]; then
+    echo
+    info "== auto-fix =="
+
+    # 4a. relink + launcher self-heal via ab.sh status (idempotent, read-mostly)
+    if [ -x "$AB" ]; then
+      if "$AB" status >/dev/null 2>&1; then
+        ok "ab.sh status ran (relink self-heal active)"
+      else
+        warn "ab.sh status exited non-zero (see above)"
+      fi
+    fi
+
+    # 4b. slot launcher materialization (20260811+ slots have no bin/dsh)
+    if [ -n "$CURRENT" ] && [ ! -x "$CURRENT/bin/dsh" ] && [ -x "$CURRENT/apps/cli/lib/bin.js" ]; then
+      mkdir -p "$CURRENT/bin"
+      cat > "$CURRENT/bin/dsh" <<'LAUNCHER'
 #!/bin/sh
 # slot launcher for snapshots without bin/dsh (20260811+): boots the compiled
 # CLI entry apps/cli/lib/bin.js (production node ESM). Regenerated by
@@ -246,32 +241,31 @@ done
 root=$(CDPATH='' cd -- "$(dirname -- "$script")/.." && pwd)
 exec node "$root/apps/cli/lib/bin.js" "$@"
 LAUNCHER
-    chmod +x "$CURRENT/bin/dsh"
-    ok "materialized $CURRENT/bin/dsh (compiled CLI entry)"
-  fi
-
-  # 4c. unknown session-event repair (ignorable marking) — DEEP layer: needs the
-  #     compiled DSH reader, so it may not load when the slot is broken. That
-  #     failure must degrade gracefully, not fail the doctor.
-  if [ -f "$REC/repair-unknown-events.mjs" ]; then
-    node "$REC/repair-unknown-events.mjs" --all >/tmp/dsh-doctor-repair.log 2>&1
-    rc=$?
-    if [ "$rc" = "0" ] || [ "$rc" = "2" ]; then
-      tail -1 /tmp/dsh-doctor-repair.log | sed 's/^/  /'
-      ok "unknown-event repair pass complete"
-    else
-      err "unknown-event repair could not run (deep layer needs the compiled DSH reader; likely the current slot is broken)."
-      err "  diagnose the slot first; the repair itself: node $REC/repair-unknown-events.mjs --all"
-      note_problem
+      chmod +x "$CURRENT/bin/dsh"
+      ok "materialized $CURRENT/bin/dsh (compiled CLI entry)"
     fi
-  fi
 
-  # --- 4d. verify fixes (re-check what we just repaired) -----------------------
-  echo
-  info "== verify fixes =="
-  PROBLEMS=0
-  if [ -f "$DSH_SOURCE/ab-config.json" ] && [ -n "$CURRENT" ]; then
-    missing=$(python3 - "$DSH_SOURCE/ab-config.json" "$CURRENT" <<'PY'
+    # 4c. unknown session-event repair (ignorable marking) — DEEP layer: needs
+    #     the compiled DSH reader; degrades gracefully when it cannot load.
+    if [ -f "$REC/repair-unknown-events.mjs" ]; then
+      node "$REC/repair-unknown-events.mjs" --all >/tmp/dsh-doctor-repair.log 2>&1
+      rc=$?
+      if [ "$rc" = "0" ] || [ "$rc" = "2" ]; then
+        tail -1 /tmp/dsh-doctor-repair.log | sed 's/^/  /'
+        ok "unknown-event repair pass complete"
+      else
+        err "unknown-event repair could not run (deep layer needs the compiled DSH reader; likely the current slot is broken)."
+        err "  diagnose the slot first; the repair itself: node $REC/repair-unknown-events.mjs --all"
+        note_problem
+      fi
+    fi
+
+    # --- 4d. verify fixes (re-check what we just repaired) ---------------------
+    echo
+    info "== verify fixes =="
+    PROBLEMS=0
+    if [ -f "$DSH_SOURCE/ab-config.json" ] && [ -n "$CURRENT" ]; then
+      missing=$(python3 - "$DSH_SOURCE/ab-config.json" "$CURRENT" <<'PY'
 import json, os, sys
 cfg, cur = sys.argv[1], sys.argv[2]
 d = json.load(open(cfg))
@@ -284,68 +278,65 @@ for ext in d.get('extensions', []):
             miss += 1
 sys.exit(1 if miss else 0)
 PY
-    )
-    rc=$?
-    if [ "$rc" = "0" ]; then
-      ok "all extension relinks present"
-    else
-      err "relinks still missing:"; printf '%s\n' "$missing" | sed 's/^/    /'
+      )
+      rc=$?
+      if [ "$rc" = "0" ]; then
+        ok "all extension relinks present"
+      else
+        err "relinks still missing:"; printf '%s\n' "$missing" | sed 's/^/    /'
+        note_problem
+      fi
+    fi
+    if [ -n "$CURRENT" ] && { [ ! -x "$CURRENT/bin/dsh" ] && [ ! -x "$CURRENT/apps/cli/lib/bin.js" ]; }; then
+      err "current slot still not bootable"
       note_problem
     fi
   fi
-  if [ -n "$CURRENT" ] && { [ ! -x "$CURRENT/bin/dsh" ] && [ ! -x "$CURRENT/apps/cli/lib/bin.js" ]; }; then
-    err "current slot still not bootable"
-    note_problem
-  fi
-fi
 
-# --- 5. restart (L0: self-contained kill + nohup + poll; the recovery skill's
-#        restart script is used when present, else doctor does it itself —
-#        the relaunch must never depend on a skill that may not be installed) --
-if [ "$FLAG_RESTART" = "1" ]; then
-  echo
-  info "== relaunching dsh web (port $PORT) =="
-  code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
-  if [ "$code" = "200" ]; then
-    ok "web already up — skipping restart"
-  else
-    if [ -f "$REC/restart-dsh-web.sh" ]; then
-      sh "$REC/restart-dsh-web.sh" >/tmp/dsh-doctor-restart.log 2>&1
-      say "  restart script: $(tail -2 /tmp/dsh-doctor-restart.log | tr '\n' ' ')"
-    else
-      say "  restarting with doctor's built-in fallback (no recovery skill present)..."
-      local_pids=$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null)
-      [ -n "$local_pids" ] && kill -TERM $local_pids 2>/dev/null || true
-      i=0; while [ "$i" -lt 30 ] && lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; do i=$((i+1)); sleep 1; done
-      ( cd "$HOME" && nohup dsh web >/tmp/dsh-web-restart.log 2>&1 & )
-    fi
-    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
+  # --- 5. restart (L0: self-contained kill + nohup + poll; the recovery skill's
+  #        restart script is used when present, else doctor does it itself) -----
+  if [ "$FLAG_RESTART" = "1" ]; then
+    echo
+    info "== relaunching dsh web (port $PORT) =="
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
     if [ "$code" = "200" ]; then
-      ok "web is UP on :$PORT after restart"
+      ok "web already up — skipping restart"
     else
-      err "web NOT up after restart (HTTP $code) — inspect the log tail above"
-      exit 2
+      if [ -f "$REC/restart-dsh-web.sh" ]; then
+        sh "$REC/restart-dsh-web.sh" >/tmp/dsh-doctor-restart.log 2>&1
+        say "  restart script: $(tail -2 /tmp/dsh-doctor-restart.log | tr '\n' ' ')"
+      else
+        say "  restarting with doctor's built-in fallback (no recovery skill present)..."
+        local_pids=$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null)
+        [ -n "$local_pids" ] && kill -TERM $local_pids 2>/dev/null || true
+        i=0; while [ "$i" -lt 30 ] && lsof -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; do i=$((i+1)); sleep 1; done
+        ( cd "$HOME" && nohup dsh web >/tmp/dsh-web-restart.log 2>&1 & )
+      fi
+      code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
+      if [ "$code" = "200" ]; then
+        ok "web is UP on :$PORT after restart"
+      else
+        err "web NOT up after restart (HTTP $code) — inspect the log tail above"
+        exit 2
+      fi
     fi
   fi
-fi
 
-# --- 5b. LLM brain (--agent): hand the deterministic report to a one-shot
-#        headless agent. The LLM reasons over the report + last activity +
-#        logs, picks (and adapts) the fix, executes it, and verifies. This is
-#        the resilient layer: deterministic rules can't anticipate a changed
-#        DSH, an LLM can read the new symptoms and reason its way out.
-if [ "$FLAG_AGENT" = "1" ]; then
-  echo
-  info "== LLM brain: handing the report to a one-shot headless agent =="
-  if ! command -v dsh >/dev/null 2>&1; then
-    err "'dsh' not on PATH — cannot launch the headless agent (fall back to: dsh-doctor --fix --restart)"
-    exit 1
-  fi
-  if ! dsh --profile headless --help >/dev/null 2>&1; then
-    err "'dsh --profile headless' unavailable — LLM brain cannot start (fall back to: dsh-doctor --fix --restart)"
-    exit 1
-  fi
-  AGENT_TASK=$(cat <<'PROMPT'
+  # --- 5b. LLM brain (--agent): hand the deterministic report to a one-shot
+  #        headless agent. Deterministic rules can't anticipate a changed DSH;
+  #        the LLM reads the new symptoms and reasons its way out.
+  if [ "$FLAG_AGENT" = "1" ]; then
+    echo
+    info "== LLM brain: handing the report to a one-shot headless agent =="
+    if ! command -v dsh >/dev/null 2>&1; then
+      err "'dsh' not on PATH — cannot launch the headless agent (fall back to: dsh-doctor --fix --restart)"
+      exit 1
+    fi
+    if ! dsh --profile headless --help >/dev/null 2>&1; then
+      err "'dsh --profile headless' unavailable — LLM brain cannot start (fall back to: dsh-doctor --fix --restart)"
+      exit 1
+    fi
+    AGENT_TASK=$(cat <<'PROMPT'
 你是 dsh web 的 out-of-band 自愈 agent（one-shot）。web（3080）挂了或状态异常，
 由你诊断根因、修复、把 web 拉回来。headless 模式下你可用工具读文件/执行命令。
 
@@ -368,22 +359,67 @@ if [ "$FLAG_AGENT" = "1" ]; then
 不确定的操作先读报告/日志再决定。不要臆造；查不到就明说。
 PROMPT
 )
-  ok "launching: dsh --profile headless <self-heal task> (report: $REPORT)"
-  dsh --profile headless "$AGENT_TASK" 2>&1 | sed 's/^/  [agent] /'
+    ok "launching: dsh --profile headless <self-heal task> (report: $REPORT)"
+    dsh --profile headless "$AGENT_TASK" 2>&1 | sed 's/^/  [agent] /'
+    echo
+    info "LLM brain finished — verify with: dsh-doctor  (or curl http://127.0.0.1:3080/)"
+  fi
+
+  # --- 6. report ---------------------------------------------------------------
   echo
-  info "LLM brain finished — verify with: dsh-doctor  (or curl http://127.0.0.1:3080/)"
+  info "== report =="
+  if [ "$PROBLEMS" = "0" ]; then
+    ok "no problems found"
+  else
+    err "$PROBLEMS problem(s) found"
+    if [ "$FLAG_FIX" = "0" ] && [ "$FLAG_AGENT" = "0" ]; then
+      say "  next: choose '2) LLM self-heal' or '3) deterministic fix + relaunch' in the menu,"
+      say "        or run: dsh-doctor --agent   (LLM)   /   dsh-doctor --fix --restart   (no LLM)"
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# doctor_menu — user-first interactive menu. One glance, no flags to remember.
+# ---------------------------------------------------------------------------
+doctor_menu() {
+  while true; do
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "http://127.0.0.1:$PORT/" 2>/dev/null || echo 000)
+    echo
+    echo "=============================================================="
+    echo "  dsh web Doctor — 一键救火"
+    echo "  当前 web(:$PORT): $([ "$code" = "200" ] && printf '✅ 正常' || printf '❌ 异常 / 未起')"
+    echo "=============================================================="
+    echo "  1) 快速体检（只读，几秒）        — 看系统哪里有问题"
+    echo "  2) LLM 智能自愈（推荐）          — 自动诊断+找根因+修复+拉起 web"
+    echo "  3) 确定性修复+拉起（不依赖 LLM） — 规则保底，web 挂得再彻底也能跑"
+    echo "  4) 退出"
+    printf "  选择 [1-4]: "
+    read -r choice || exit 0
+    case "$choice" in
+      1) FLAG_FIX=0; FLAG_RESTART=0; FLAG_AGENT=0; doctor_run ;;
+      2) ( FLAG_FIX=0; FLAG_RESTART=0; FLAG_AGENT=1; exec > >(tee "$REPORT") 2>&1; doctor_run ) ;;
+      3) FLAG_FIX=1; FLAG_RESTART=1; FLAG_AGENT=0; doctor_run ;;
+      4) echo "bye"; exit 0 ;;
+      *) echo "  无效选择，请输入 1-4"; continue ;;
+    esac
+    echo
+    printf "  按回车返回菜单..."; read -r _ || true
+  done
+}
+
+# --- entry point ---------------------------------------------------------------
+# No flags + interactive terminal → menu (the user-first path).
+if [ "$FLAG_FIX" = "0" ] && [ "$FLAG_RESTART" = "0" ] && [ "$FLAG_AGENT" = "0" ] && [ -t 0 ]; then
+  doctor_menu
+  exit 0
 fi
 
-# --- 6. report ---------------------------------------------------------------
-echo
-info "== report =="
-if [ "$PROBLEMS" = "0" ]; then
-  ok "no problems found"
-  exit 0
-else
-  err "$PROBLEMS problem(s) found"
-  if [ "$FLAG_FIX" = "0" ]; then
-    say "  re-run with --fix to auto-repair, --restart to relaunch web"
-  fi
-  exit 1
+# --agent: the LLM is the doctor's brain — tee every deterministic check to
+# the report file the headless agent will read.
+if [ "$FLAG_AGENT" = "1" ]; then
+  exec > >(tee "$REPORT") 2>&1
 fi
+
+doctor_run
+exit $?


### PR DESCRIPTION
User-first: too many flags to remember. Bare `dsh-doctor` on a terminal now shows an interactive menu with web status + 4 choices (1 quick check / 2 LLM self-heal recommended / 3 deterministic fix+relaunch / 4 exit). Non-tty keeps read-only diagnose; flag mode unchanged for automation.

Also documents the headless dependency surface (verified 2026-08-11): `dsh --profile headless` loads only dsh-base + dsh-headless — NOT the web's extension bundles (dsh-track etc.), so extension faults don't stop the LLM brain; it DOES load skills and depends on slot compiled packages + LLM credentials — when those break, menu 3 / --fix is the fallback.