### PR TITLE
feat(web-doctor): generic plugin coverage — any bundle's deps, not just ab-config'd

### DIFF
--- a/skills/dsh-web-doctor/SKILL.md
+++ b/skills/dsh-web-doctor/SKILL.md
@@ -2,8 +2,8 @@
 name: dsh-web-doctor
 description: >-
   dsh web 挂了/A/B 双槽都起不来时的 out-of-band 医生：不依赖 web 进程，纯终端一键诊断
-  （web 健康、launcher 链、扩展 relink、槽可启动性、session 存储、web.log、最近会话最后发生的事）
-  → 确定性自动修复（relink 自愈、bin/dsh 补位、未知事件 ignorable、损坏日志修复）→ 把 web 拉回来并验证；
+  （web 健康、launcher 链、扩展 relink、**任意插件的依赖完整性**、槽可启动性、session 存储、web.log、最近会话最后发生的事）
+  → 确定性自动修复（relink 自愈、**任意插件依赖自愈**、bin/dsh 补位、未知事件 ignorable、损坏日志修复）→ 把 web 拉回来并验证；
   或 --agent 模式交给 headless LLM agent（读报告+日志推理根因、自适应修复、验证），应对 DSH 改版与新故障模式。
   当用户说"web 挂了怎么查"、"dsh web 起不来"、"3080 挂了"、"怎么自愈"、"跑一下 doctor"、
   "看看系统为什么挂了"时使用，即使 GUI/agent 都不可用（终端跑 dsh-doctor，无参数即交互菜单：体检/LLM 自愈/确定性修复+拉起）。
@@ -75,7 +75,7 @@ dsh-doctor --quiet            # 少输出
 |---|---|
 | （无） | 交互菜单（终端）；管道/脚本下退化为只读诊断 |
 | `--agent` | **LLM 主脑**：体检报告 tee 到 `/tmp/dsh-doctor-report.txt` → `dsh --profile headless` 起 one-shot LLM agent（内置自愈 prompt）→ 读报告+日志推理根因 → 用确定性原语（或直接命令）修复 → 验证 200 → 输出结论 |
-| `--fix` | 确定性自动修复：relink 自愈 → bin/dsh 补位 → 会话未知事件 ignorable → 损坏日志修复 → **verify 重查**（不依赖 LLM） |
+| `--fix` | 确定性自动修复：relink 自愈 → **任意插件依赖自愈**（plugin-deps-check）→ bin/dsh 补位 → 会话未知事件 ignorable → 损坏日志修复 → **verify 重查**（不依赖 LLM） |
 | `--restart` | 修复后拉起 web（kill 旧 + nohup 重启 + 轮询 HTTP 200）；web 已 200 则跳过 |
 
 ## 分层：确定性是"手和眼"，LLM 是"大脑"
@@ -117,8 +117,14 @@ bash-sandbox/fs-policy/commands）。
 4. **槽可启动**：current 有 `bin/dsh` 或编译产物 `apps/cli/lib/bin.js`。
 5. **session 存储（L0 文件层）**：`session-store-check.mjs` 逐日志校验可解压、header 正确、
    尾部合法 JSON——**只用 node 标准库 + zstd CLI，不加载任何 DSH 编译包**。
-6. **web.log 尾部**：最近启动失败的直接证据。
-7. **最近会话"最后发生的事"**：`session-last-activity.mjs` 列最近活跃会话的最后事件
+6. **web.log 尾部 + boot 失败提示**：`tail` 最近失败 + 自动提取 `Cannot find package` /
+   `failed to import loader entry` / `plugin tree failed to load` 关键错误（插件类故障的直接线索）。
+7. **profile bundles 依赖检查（任何插件）**：`plugin-deps-check.mjs` 读 web profile 的
+   `dependencies`（out-of-tree bundles），扫描每个插件 `lib/` 产物的 `@deepseek-ai/*` /
+   `cordis` import vs 其 node_modules——**不依赖 ab-config**，未来装的任何插件（dsh-loop、
+   dsh-kb-sieve…）缺失依赖都会被抓住；缺失时自动从 current 槽 packages 按包名找修复来源
+   （`FIXABLE`）或报告无来源（`MISSING`）。
+8. **最近会话"最后发生的事"**：`session-last-activity.mjs` 列最近活跃会话的最后事件
    （类型/seq/时间/内容提示）——"挂了之前系统在做什么"。
 
 ## 依赖分层（极小依赖设计）

--- a/skills/dsh-web-doctor/scripts/doctor.sh
+++ b/skills/dsh-web-doctor/scripts/doctor.sh
@@ -193,14 +193,36 @@ PY
     fi
   fi
 
-  # 3f. web.log tail
+  # 3f. web.log tail + boot-failure hints
   if [ -f "$DSH_SOURCE/web.log" ]; then
     echo
     say "== web.log tail =="
     tail -8 "$DSH_SOURCE/web.log" | sed 's/^/  /' >&2
+    boot_err=$(grep -oE "Cannot find package '[^']+'|failed to import loader entry [a-zA-Z_-]+|plugin tree failed to load[^;]*" "$DSH_SOURCE/web.log" 2>/dev/null | tail -3)
+    if [ -n "$boot_err" ]; then
+      echo
+      warn "  boot failure hints (likely cause of a plugin-related outage):"
+      printf '%s\n' "$boot_err" | sed 's/^/    /' >&2
+    fi
   fi
 
-  # 3g. what happened last (most recently active sessions)
+  # 3g. generic plugin dependency check — ANY out-of-tree bundle in the web
+  #     profile (not just ab-config'd ones): dsh-loop, dsh-kb-sieve, whatever
+  #     gets installed later. A missing dep here is a boot-killer.
+  PDEPS="$SKILLS_DIR/dsh-web-doctor/scripts/plugin-deps-check.mjs"
+  if [ -f "$PDEPS" ]; then
+    echo
+    say "== profile bundles dependency check =="
+    while IFS= read -r line; do
+      case "$line" in
+        FIXABLE:*) warn "  $line" ;;
+        MISSING:*) err "  $line"; note_problem ;;
+        ok:*) say "  $line" ;;
+      esac
+    done < <(node "$PDEPS" 2>&1)
+  fi
+
+  # 3h. what happened last (most recently active sessions)
   echo
   say "== last activity in recent sessions =="
   if [ -f "$SKILLS_DIR/dsh-web-doctor/scripts/session-last-activity.mjs" ]; then
@@ -260,7 +282,25 @@ LAUNCHER
       fi
     fi
 
-    # --- 4d. verify fixes (re-check what we just repaired) ---------------------
+    # 4d. generic plugin dependency self-heal (any bundle; source auto-found in
+    #     the current slot's packages by package name — no ab-config mapping)
+    if [ -f "$PDEPS" ]; then
+      while IFS= read -r line; do
+        case "$line" in
+          FIXABLE:*)
+            pkg=$(printf '%s' "$line" | sed 's/FIXABLE: \([^ ]*\).*/\1/')
+            repo=$(printf '%s' "$line" | sed 's/.*repo=\([^ ]*\).*/\1/')
+            src=$(printf '%s' "$line" | sed 's/.*-> //')
+            link="$repo/node_modules/$pkg"
+            mkdir -p "$(dirname "$link")"
+            ln -sfn "$src" "$link"
+            ok "  plugin dep self-heal: $link -> $src"
+            ;;
+        esac
+      done < <(node "$PDEPS" 2>&1)
+    fi
+
+    # --- 4e. verify fixes (re-check what we just repaired) ---------------------
     echo
     info "== verify fixes =="
     PROBLEMS=0
@@ -348,8 +388,15 @@ PY
    看最近会话最后发生的事；tail ~/.dsh/source/web.log。
 4. 找根因 → 修复。优先复用确定性原语：
    bash ~/.dsh/skills/dsh-web-doctor/scripts/doctor.sh --fix
-   （relink 自愈 / bin/dsh 补位 / 未知事件 ignorable / 损坏日志修复）；
-   也可直接执行修复命令（如 ln -sfn 重建扩展链接）。
+   （relink 自愈 / 插件依赖自愈 / bin/dsh 补位 / 未知事件 ignorable / 损坏日志修复）；
+   也可直接执行修复命令。
+   若是【任何插件】导致 boot 失败（报错含 Cannot find package / failed to import
+   loader entry / plugin tree failed to load）：
+   a. 读 ~/.dsh/profiles/web/package.json 的 dependencies/bundles 定位是哪个插件；
+   b. 修其依赖（node ~/.dsh/skills/dsh-web-doctor/scripts/plugin-deps-check.mjs
+      看 FIXABLE/MISSING；MISSING 且槽里没有 → 该插件缺依赖，需重装或隔离）；
+   c. 必要时隔离该插件（dsh plugin --profile web remove <pkg>）让 web 先起来，
+      再单独修插件。
 5. 验证：curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3080/ 应为 200；
    若 web 未起，用 restart-dsh-web.sh 或 nohup dsh web 拉起。
 6. 最终输出（简洁中文）：根因一句话、做了什么、当前 web 状态；

--- a/skills/dsh-web-doctor/scripts/plugin-deps-check.mjs
+++ b/skills/dsh-web-doctor/scripts/plugin-deps-check.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * plugin-deps-check.mjs — GENERIC extension/bundle dependency integrity check.
+ *
+ * Not tied to ab-config (which only knows dsh-track): it reads a dsh profile
+ * (default web), finds every OUT-OF-TREE bundle (dependencies resolved as
+ * link:/file:), scans each repo's built lib for bare @deepseek-ai/* / cordis
+ * imports, and reports any package missing from that repo's node_modules.
+ * For each missing package it also tries to find a matching package dir in
+ * the current slot's packages/ tree (by package.json name) — that is the
+ * generic fix source (no ab-config mapping needed), covering ANY plugin.
+ *
+ * Minimal deps: node built-ins + zstd not even needed here (we scan lib/ on
+ * disk; the extension's own node_modules is a symlink farm). Out-of-band.
+ *
+ * Usage:
+ *   node plugin-deps-check.mjs [--profile web] [--slot <dir>]
+ * Output lines:
+ *   ok:      <pkg> (<dep-name>)
+ *   FIXABLE: <pkg> (<dep-name>) repo=<repo> -> <slot-package-dir>  # missing; fix source found
+ *   MISSING: <pkg> (<dep-name>) repo=<repo>                        # missing; no slot source
+ * Exit 0 = all present, 1 = at least one missing (fixable or not).
+ */
+import { parseArgs } from 'node:util'
+import { readFileSync, readdirSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { homedir } from 'node:os'
+
+const { values } = parseArgs({
+  options: {
+    profile: { type: 'string', default: 'web' },
+    slot: { type: 'string' },
+  },
+})
+const PROFILE_DIR = values.profile.startsWith('/')
+  ? values.profile
+  : join(homedir(), '.dsh', 'profiles', values.profile)
+const SLOT = values.slot ?? (() => {
+  const c = join(homedir(), '.dsh', 'source', 'current')
+  try { return readFileSync(c, 'utf8').trim() } catch { return c }
+})()
+
+function walk(dir, out = []) {
+  let entries
+  try { entries = readdirSync(dir, { withFileTypes: true }) } catch { return out }
+  for (const e of entries) {
+    if (e.name === 'node_modules') continue
+    const p = join(dir, e.name)
+    if (e.isDirectory()) walk(p, out)
+    else if (e.name.endsWith('.js') && e.name !== 'client.js' && !p.includes('/types/')) out.push(p)
+  }
+  return out
+}
+
+/** Find a package dir under slot/packages whose package.json name matches. */
+function findSlotPackage(spec) {
+  const pkgs = join(SLOT, 'packages')
+  const queue = [pkgs]
+  while (queue.length) {
+    const dir = queue.shift()
+    let entries
+    try { entries = readdirSync(dir, { withFileTypes: true }) } catch { continue }
+    for (const e of entries) {
+      const p = join(dir, e.name)
+      if (e.isDirectory()) {
+        const pj = join(p, 'package.json')
+        if (existsSync(pj)) {
+          try {
+            const d = JSON.parse(readFileSync(pj, 'utf8'))
+            if (d.name === spec) return p
+          } catch { /* keep walking */ }
+        }
+        queue.push(p)
+      }
+    }
+  }
+  return undefined
+}
+
+const IMPORT_RE = /(?:from|import\s*\(\s*|import\s+[^'"]*?from\s+)['"](@deepseek-ai\/[^'"]+|cordis)['"]/g
+
+const manifest = join(PROFILE_DIR, 'package.json')
+let pkg
+try { pkg = JSON.parse(readFileSync(manifest, 'utf8')) } catch {
+  console.error(`cannot read profile manifest: ${manifest}`)
+  process.exit(2)
+}
+
+let missingAny = 0
+const seen = new Set()
+for (const [depName, spec] of Object.entries(pkg.dependencies ?? {})) {
+  let repo
+  if (spec.startsWith('link:') || spec.startsWith('file:')) repo = spec.slice(5)
+  else continue // registry deps are managed by pnpm, not our relinks
+  if (!repo || !existsSync(join(repo, 'package.json'))) continue
+  if (seen.has(repo)) continue
+  seen.add(repo)
+  const imports = new Set()
+  for (const f of walk(repo)) {
+    const text = readFileSync(f, 'utf8')
+    for (const m of text.matchAll(IMPORT_RE)) imports.add(m[1])
+  }
+  for (const spec2 of [...imports].sort()) {
+    if (existsSync(join(repo, 'node_modules', spec2))) {
+      console.log(`ok:      ${spec2} (${depName})`)
+    } else {
+      const src = findSlotPackage(spec2)
+      if (src) {
+        console.log(`FIXABLE: ${spec2} (${depName}) repo=${repo} -> ${src}`)
+      } else {
+        console.log(`MISSING: ${spec2} (${depName}) repo=${repo}`)
+      }
+      missingAny = 1
+    }
+  }
+}
+process.exit(missingAny)


### PR DESCRIPTION
The doctor only checked ab-config extensions (dsh-track). A future plugin (dsh-loop, dsh-kb-sieve...) breaking web boot would go unnoticed. Now diagnosis is profile-driven and generic:

- `plugin-deps-check.mjs`: reads the web profile's out-of-tree bundles (link:/file: deps), scans each plugin's built lib for bare @deepseek-ai/* / cordis imports vs its node_modules — NOT tied to ab-config. Missing deps auto-find a fix source by walking the current slot's packages/ tree matching package.json name (FIXABLE) or report MISSING.
- doctor.sh: diagnosis gains generic plugin dep check + web.log boot-failure hint extraction (Cannot find package / failed to import loader entry / plugin tree failed to load); --fix gains generic dep self-heal.
- --agent prompt: locate which bundle breaks boot, fix deps or isolate (dsh plugin --profile web remove).
- Verified: hiding dsh-llm → FIXABLE with auto-found slot source; --fix restores; dsh-restart-recover (no @deepseek-ai imports) reports nothing.