### PR TITLE
docs: README doctor chapter (bilingual) + web-doctor motivation doc

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -53,6 +53,54 @@ dsh-harness-ops (this repo)
 - Daily upgrade: `$AB discover → prepare → switch --yes → confirm`
 - Self-heal check: `kill $(lsof -ti :3080)` → auto-restart within 10s → session continues (no manual step)
 
+## 🚑 Total-outage fallback: dsh-web-doctor (one-shot rescue when web/A/B are all down)
+
+> Why it exists: two incidents on 2026-08-11 (web would not boot after a switch; an extension
+> link was wiped externally) cost hours of hands-on recovery — every step (read the last session
+> activity → find the root cause → fix relinks → fix sessions → relaunch web) is scriptable, and
+> what was missing is a one-command entry that does NOT depend on the web. Full motivation and
+> the incident chain: [`docs/web-doctor-motivation.md`](docs/web-doctor-motivation.md).
+
+**When to use**: web (3080) is down / won't boot / both A/B slots are broken / GUI and agent are
+unavailable (the agent lives inside the web process). It is **out-of-band**: terminal + local
+tools (node/zstd/jq/curl/ps/lsof), **no web process, no extension bundle loaded**.
+
+**How to use** (user-first, no flags to remember):
+
+```sh
+dsh-doctor                    # interactive menu (English default; option 5 switches to Chinese)
+```
+
+```
+==============================================================
+  dsh web Doctor — one-shot rescue        // dsh web 医生 — 一键救火
+  web(:3080): ✅ healthy                  // 当前 web: ✅ 正常
+==============================================================
+  1) Quick check (diagnose only)          // 快速体检（只读）
+  2) LLM auto-repair (recommended)        // 大模型自动修复（推荐）：LLM 读诊断+日志
+                                          //   推理根因，发现/修复任意插件问题
+  3) Fix config issues (mechanical)      // 修复配置问题（机械，不依赖 LLM）：relink/
+     incl. relaunch web                  //   插件依赖/launcher/session/LLM 凭据等
+                                          //   已知配置故障
+  4) Exit                                 // 退出
+  5) Switch language 中文                 // 切换语言
+```
+
+**Layered design (why)**:
+- **Deterministic layer** (option 3): sensors + actuators — seconds, zero LLM cost, runs even
+  when everything is broken; covers known config faults (relinks / plugin deps / launcher /
+  sessions / LLM credentials); skips repair automatically when the diagnosis is all green
+- **LLM brain** (option 2): a one-shot `dsh --profile headless` agent reads the report + logs
+  and reasons about the root cause — it can find/fix what deterministic rules cannot (DSH core
+  incompatibility, a plugin that scrambled its config, new failure modes); headless does NOT
+  load the web's extension bundles, so extension faults don't stop it
+
+**9 diagnosis checks**: web health / launcher chain / extension relinks / slot bootability /
+session file-layer (97 logs) / web.log (classified: historical vs current fault) / profile
+bundle deps (any plugin) / LLM config (.env key) / last activity in recent sessions.
+
+---
+
 **Official-change digest (daily analysis)**: the official repo ships **no CHANGELOG**, but it
 **requires** an **Agent Note** per non-trivial change (`.agents/notes/implemented/<class>/
 yyyy-mm-dd-<topic>.md`, class ∈ feature / bug-fix / simplification / architecture / process /

--- a/README.md
+++ b/README.md
@@ -47,6 +47,50 @@ dsh-harness-ops（本仓库）
 - 每日升级：`$AB discover → prepare → switch --yes → confirm`
 - 自愈验证：`kill $(lsof -ti :3080)` → 10s 内自动拉起 → 会话自动继续（无需手动）
 
+## 🚑 全挂兜底：dsh-web-doctor（web/A/B 全挂时的一键救火）
+
+> 为什么有它：2026-08-11 两次事故（切换后 web 起不来、扩展链接被外部清理）现场修复耗了数小时——
+> 每一步（查 session 最后事件 → 找根因 → 修 relink → 修会话 → 拉起 web）其实都能脚本化，缺的
+> 是一个**不依赖 web 的一键入口**。完整动机与事故链见 [`docs/web-doctor-motivation.md`](docs/web-doctor-motivation.md)。
+
+**什么时候用**：web（3080）挂了 / 起不来 / A/B 双槽都坏 / GUI 和 agent 都不可用
+（agent 由 web 托管，web 挂 = 没有 agent 可用）。它是 **out-of-band** 的：纯终端 + 本机工具
+（node/zstd/jq/curl/ps/lsof），**不依赖 web 进程、不加载任何扩展**。
+
+**怎么用**（用户角度，不用记参数）：
+
+```sh
+dsh-doctor                    # 交互菜单（默认英文，菜单里选 5 切中文）
+```
+
+```
+==============================================================
+  dsh web Doctor — one-shot rescue        // dsh web 医生 — 一键救火
+  web(:3080): ✅ healthy                  // 当前 web: ✅ 正常
+==============================================================
+  1) Quick check (diagnose only)          // 快速体检（只读）
+  2) LLM auto-repair (recommended)        // 大模型自动修复（推荐）：LLM 读诊断+日志
+                                          //   推理根因，发现/修复任意插件问题
+  3) Fix config issues (mechanical)      // 修复配置问题（机械，不依赖 LLM）：relink/
+     incl. relaunch web                  //   插件依赖/launcher/session/LLM 凭据等
+                                          //   已知配置故障
+  4) Exit                                 // 退出
+  5) Switch language 中文                 // 切换语言
+```
+
+**分层设计**（为什么这样）：
+- **确定性层**（菜单 3）：传感器+执行器——秒级、零 LLM 成本、web 挂得再彻底也能跑；
+  覆盖已知配置故障（relink/插件依赖/launcher/session/LLM 凭据）；诊断全绿时自动跳过修复
+- **LLM 大脑**（菜单 2）：`dsh --profile headless` 起 one-shot agent，读报告+日志推理根因，
+  **能发现/修复确定性规则想不到的问题**（DSH 核心不兼容改动、插件配置被改乱、新故障模式）；
+  headless 不加载 web 的扩展 bundle，所以扩展故障不影响它
+
+**诊断 9 项**：web 健康 / launcher 链 / 扩展 relink / 槽可启动 / session 文件层（97 个日志）/
+web.log（分类历史残留 vs 当前故障）/ profile bundles 依赖（任意插件）/ LLM 配置（.env key）/
+最近会话最后发生的事。
+
+---
+
 **官方改动提炼（每日分析）**：官方仓库没有 CHANGELOG 文档，但**强制**每个非平凡改动写一篇
 **Agent Note**（`.agents/notes/implemented/<class>/yyyy-mm-dd-<topic>.md`，class ∈ feature /
 bug-fix / simplification / architecture / process / testing，每篇带 `.zh.md` + `.i18n.yaml`，

--- a/docs/web-doctor-motivation.en.md
+++ b/docs/web-doctor-motivation.en.md
@@ -1,0 +1,97 @@
+# dsh-web-doctor — motivation & incident chain (2026-08-11 → 08-12)
+
+> 中文版：[web-doctor-motivation.md](web-doctor-motivation.md)
+
+## Why this exists
+
+On 2026-08-11, three "web won't boot"-related incidents happened on the same machine in one
+day; each cost tens of minutes to hours of hands-on recovery. Looking back, **every step was
+scriptable** — what was missing was a one-command entry that does NOT depend on the web
+process. The doctor fills that gap.
+
+## The incidents (why it hurts)
+
+### Incident 1: web down after the AB switch (08-11 17:49)
+
+- The 0811 snapshot switch succeeded (`current → slot-a`) but the web restart failed; 3080 was
+  down ~9 minutes.
+- **Root cause A**: the 0811 snapshot **removed `bin/dsh`** (boot moved from the tsx source
+  launcher to the compiled `apps/cli/lib/bin.js`); the launcher chain
+  `~/.local/bin/dsh → current/bin/dsh` broke.
+- **Root cause B (deeper)**: the dsh-track extension gained a `@deepseek-ai/dsh-llm`
+  dependency that was missing from the ab-config relink map. **build/test/smoke all green yet
+  production failed** — build/test resolve via tsconfig paths / vitest aliases, smoke boots via
+  tsx (which also reads tsconfig paths); **only production is pure node ESM (node_modules
+  only)**.
+- Manual fix: add a `bin/dsh` wrapper + `ln -sfn` dsh-llm.
+
+### Incident 2: the same dsh-llm link wiped externally (08-11 20:44–22:52)
+
+- A manually-`ln`'d link is **unowned** (neither pnpm nor ab.sh manages it); some operation that
+  touched `node_modules/@deepseek-ai/` removed it; **no mechanism detected or restored it**
+  until the user ran `dsh web` again (22:52) and it failed.
+
+### Incident 3: a session would not open (08-11 night)
+
+- Custom events (`track/sync-preview` etc.) written into session logs by 0810-era dsh-track are
+  unknown to the 0811 event whitelist → `SessionFormatUnsupportedError`; 6 old sessions became
+  unreadable (official stance: refuse to read rather than misread).
+
+## The manual recovery loop (what cost time)
+
+1. **Read what happened last**: decompress session.jsonl.zstd, look at tail events → "what was
+   the system doing before it went down".
+2. **Find the root cause**: check web.log / launcher chain / relink existence one by one.
+3. **Fix** relinks / add bin/dsh / repair session format.
+4. **Relaunch web** + verify HTTP 200.
+
+Every step can be scripted; at the time it was manual commands plus human (or LLM) judgement.
+
+## Key insight: why it must be out-of-band
+
+- **The agent lives inside the web process** — web down means GUI AND agent are both
+  unavailable; no "intelligence" is left to help.
+- So the rescue tool must be **terminal + local tools only** (node/zstd/jq/curl/ps/lsof), zero
+  web dependency.
+- But a purely deterministic script has a fatal flaw: **hard-coded rules go stale when DSH
+  changes** (0811 deleted `bin/dsh`); new failure modes are unanticipated.
+
+## Why "deterministic + LLM" layers
+
+| Layer | Why needed | Limits |
+|---|---|---|
+| **Deterministic** (check + fix primitives) | seconds, zero LLM cost, runs when everything is broken; gives the LLM reliable facts and executable actions | rules go stale; new faults unanticipated |
+| **LLM brain** (headless one-shot agent) | reads the report + logs and reasons about the root cause; adapts to DSH changes / core incompatibilities / a plugin that scrambled its config | needs the harness itself (compiled packages + credentials) to run; slow, costs tokens |
+
+Live proof of LLM value: on a healthy system it read the report and **independently judged**
+the web.log `node: not found` lines as 8/10 history, not the current fault — something a
+deterministic rule cannot do (rules only list).
+
+## Evolution (script → full tool in one day)
+
+1. `doctor.sh`: 9 deterministic checks + repair + relaunch (out-of-band by construction).
+2. Minimal-dependency layers: L0 self-contained (node built-ins + zstd, no compiled packages) /
+   L1 deep, degrades.
+3. `dsh-doctor` short PATH entry + slot-bin entry + `--help`.
+4. Interactive menu (no args = menu; English default, Chinese switchable).
+5. LLM brain `--agent` (headless one-shot + self-heal prompt).
+6. Generic plugin coverage `plugin-deps-check` (profile-driven, not ab-config; checks ANY bundle).
+7. LLM credential repair (interactive key input / config backup-reset / permission normalize).
+8. Honesty pass: skip repair when healthy; classify web.log historical vs current; menu reflects
+   real capability.
+
+## Capability and honest boundaries
+
+**Can do automatically**: 9 checks → fix known config faults (relinks / plugin deps / launcher /
+sessions / LLM credentials) → LLM reasoning for unknown problems → relaunch web → verify.
+
+**Cannot do (honest)**: the LLM API key itself must come from the user (doctor guides the input
+and configures it, never invents one); external causes (key expired/quota) can only be reported;
+decisions that need a human (e.g. "should we roll back the slot") are reported clearly, never
+acted on silently.
+
+## Related docs
+
+- `skills/dsh-web-doctor/SKILL.md` — user manual (bilingual menu, checks, layers, boundaries)
+- `skills/dsh-snapshot-ab/references/postmortem-ab-switch-20260811.md` — full post-mortem of incident 1
+- `skills/dsh-session-recovery/SKILL.md` — session repair (incident 3)

--- a/docs/web-doctor-motivation.md
+++ b/docs/web-doctor-motivation.md
@@ -1,0 +1,83 @@
+# dsh-web-doctor 动机与事故链（2026-08-11 → 08-12）
+
+> English: [web-doctor-motivation.en.md](web-doctor-motivation.en.md)
+
+## 为什么有这个东西
+
+2026-08-11 一天之内，同一台机器上发生了**三次**与"web 起不来"相关的事故，现场手工修复
+每次都要数十分钟到数小时。事后回看，**每一步其实都能脚本化**——缺的只是一个不依赖 web
+进程的一键入口。doctor 就是补上这个缺口的产物。
+
+## 事故链（为什么我们痛）
+
+### 事故 1：AB 切换后 web 起不来（08-11 17:49）
+
+- 0811 快照切换（`ab.sh switch`）成功，`current → slot-a`，但 web 重启失败，3080 停机约 9 分钟
+- **根因 A**：0811 快照**删除了 `bin/dsh`**（启动方式从 `bin/dsh` tsx 源码运行改为编译产物
+  `apps/cli/lib/bin.js`），launcher 链 `~/.local/bin/dsh → current/bin/dsh` 断掉
+- **根因 B（更深）**：扩展 `dsh-track` 新增依赖 `@deepseek-ai/dsh-llm`，但 ab-config 的 relink
+  列表漏了它。**build/test/冒烟全绿却生产挂**——因为 build/test 走 tsconfig paths / vitest
+  alias、冒烟走 tsx（tsx 也读 tsconfig paths），**只有生产是纯 node ESM（只认 node_modules）**
+- 手工修复：补 `bin/dsh` 包装器 + `ln -sfn` dsh-llm
+
+### 事故 2：同一个 dsh-llm 链接又被外部清理（08-11 20:44–22:52）
+
+- 手工 `ln` 建的链接是**无主资产**（不在 pnpm、不在 ab.sh 管理内），被某个碰
+  `node_modules/@deepseek-ai/` 的操作清掉；**没有任何机制发现或恢复**，直到用户手动
+  `dsh web` 再挂一次（22:52）才发现
+
+### 事故 3：session 打不开（08-11 晚）
+
+- 0810 时期 dsh-track 写进会话日志的自定义事件（`track/sync-preview` 等），0811 快照的事件
+  白名单不认识 → `SessionFormatUnsupportedError`，6 个旧会话历史读不出（官方立场：宁拒读不误读）
+
+## 现场修复过程（手工版，耗时点）
+
+1. **查 session 最后发生的事**：解压 session.jsonl.zstd 看尾部事件 → 判断"挂之前系统在做什么"
+2. **找根因**：web.log / launcher 链 / relink 存在性逐项排查
+3. **修 relink / 补 bin/dsh / 修 session 格式**
+4. **拉起 web** + 验证 200
+
+每一步都能写成脚本，但当时是逐条命令手工跑 + 靠人（或 LLM）判断。
+
+## 关键洞察：为什么必须 out-of-band
+
+- **agent 由 web 进程托管**——web 挂了 = GUI 和 agent 全部不可用，没有任何"智能"能帮你
+- 所以救火工具必须**纯终端 + 本机工具**（node/zstd/jq/curl/ps/lsof），零 web 依赖
+- 但纯确定性脚本有个致命伤：**写死的规则会随 DSH 改版失效**（0811 就删了 `bin/dsh`），
+  新故障模式规则想不到
+
+## 为什么"确定性 + LLM"分层
+
+| 层 | 为什么需要 | 局限 |
+|---|---|---|
+| **确定性**（检查原语 + 修复原语） | 秒级、零 LLM 成本、web 挂得再彻底也能跑；给 LLM 提供可靠事实和可执行动作 | 规则会过时；新故障想不到 |
+| **LLM 大脑**（headless one-shot agent） | 读报告+日志自己推理根因；DSH 改版/核心不兼容/插件配置被改乱都能适应 | 依赖 harness 本身（编译产物+凭据）能跑；慢、烧 token |
+
+实测 LLM 价值：健康系统上它读完报告后**自己判断出** web.log 的 `node: not found` 是
+8/10 历史残留而非当前故障——这是确定性规则做不到的（规则只会罗列）。
+
+## 演进历史（一天内从脚本到完整工具）
+
+1. `doctor.sh`：9 项确定性诊断 + 修复 + 拉起（out-of-band 构造）
+2. 极小依赖分层：L0 自包含（node 内置+zstd，不加载编译产物）/ L1 深度可降级
+3. `dsh-doctor` 短命令入口（PATH）+ 槽 bin 双入口 + `--help`
+4. 交互菜单（无参数即用，默认英文可切中文）
+5. LLM 大脑 `--agent`（headless one-shot + 自愈 prompt）
+6. 通用插件覆盖 `plugin-deps-check`（profile 驱动，不认 ab-config，任何插件都查）
+7. LLM 凭据修复（交互补 key / 配置备份重置 / 权限归一化）
+8. 诚实化：无故障跳过修复；web.log 历史 vs 当前分类；菜单如实描述能力
+
+## 现状能力与诚实边界
+
+**能自动做**：诊断 9 项 → 修复已知配置故障（relink/插件依赖/launcher/session/LLM 凭据）→
+LLM 推理未知问题 → 拉起 web → 验证。
+
+**做不了（如实说）**：LLM API key 本身只能用户提供（doctor 引导输入并代为配置，绝不臆造）；
+key 失效/欠费等外部原因只能提示；真正需要人决策的（如"要不要回滚槽"）会明确报告而不是擅动。
+
+## 相关文档
+
+- `skills/dsh-web-doctor/SKILL.md` — 使用手册（双语菜单、诊断项、分层、边界）
+- `skills/dsh-snapshot-ab/references/postmortem-ab-switch-20260811.md` — 事故 1 完整复盘
+- `skills/dsh-session-recovery/SKILL.md` — 会话修复（事故 3）


### PR DESCRIPTION
- README.md / .en.md: dedicated 'total-outage fallback: dsh-web-doctor' chapter — when to use, the bilingual interactive menu, deterministic-vs-LLM layering, the 9 diagnosis checks.
- docs/web-doctor-motivation.md (+ .en.md): the full incident chain (08-11 switch outage / wiped dsh-llm link / unreadable sessions), the manual recovery loop that motivated it, the out-of-band requirement, the deterministic+LLM rationale, the day's evolution, honest boundaries.