### PR TITLE
fix(web-doctor): stream the agent's REASONING, not just tool calls

### DIFF
--- a/skills/dsh-web-doctor/scripts/doctor.sh
+++ b/skills/dsh-web-doctor/scripts/doctor.sh
@@ -581,9 +581,10 @@ for line in sys.stdin:
     data = d.get("data", {}) or {}
     txt = ""
     if t == "reasoning-chunks":
-        txt = (data.get("text", "") or "").strip()
+        # reasoning lives in data.texts (an array of tokens) — join them
+        txt = "".join(data.get("texts") or [data.get("text", "")] or []).strip()
     elif t in ("assistant/chunk", "text-chunks"):
-        txt = (data.get("text", "") or "").strip()
+        txt = "".join(data.get("texts") or [data.get("text", "")] or []).strip()
     elif t == "tool/call":
         a = data.get("arguments", data.get("input", ""))
         txt = ("tool " + str(data.get("name", "?")) + " " + (str(a)[:120] if isinstance(a, str) else ""))


### PR DESCRIPTION
The live log showed tool calls but hid the thinking. Root cause: headless session logs store reasoning tokens in data.texts (an array); the extractor read data.text (single field) — so reasoning never surfaced.

- reasoning-chunks / text-chunks / assistant/chunk extraction now joins data.texts (fallback data.text); the [llm] stream shows the full chain of thought, then the tool calls it decided on, then results.
- Verified: --force streams 175 [llm] lines in 40s — complete think-then-act trace.