### PR TITLE
docs: README developer-view intro + doctor menu order + postmortem follow-up

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -77,23 +77,31 @@ dsh-doctor                    # interactive menu (English default; option 5 swit
   web(:3080): ✅ healthy                  // 当前 web: ✅ 正常
 ==============================================================
   1) Quick check (diagnose only)          // 快速体检（只读）
-  2) LLM auto-repair (recommended)        // 大模型自动修复（推荐）：LLM 读诊断+日志
-                                          //   推理根因，发现/修复任意插件问题
-  3) Fix config issues (mechanical)      // 修复配置问题（机械，不依赖 LLM）：relink/
+  2) Fix config issues (mechanical)      // 修复配置问题（机械，不依赖 LLM）：relink/
      incl. relaunch web                  //   插件依赖/launcher/session/LLM 凭据等
                                           //   已知配置故障
-  4) Exit                                 // 退出
-  5) Switch language 中文                 // 切换语言
+  3) LLM repair (recommended)            // LLM 修复（推荐）：LLM 读诊断+日志推理根因，
+                                          //   发现/修复任意插件问题（含核心不兼容、
+                                          //   插件配置被改乱）
+  4) Deep LLM check & repair (always)   // LLM 深度检测和修复（每次都跑，不因诊断
+                                          //   全绿跳过；完整思维链实时展示）
+  5) Exit                                 // 退出
+  6) Switch language 中文                 // 切换语言
 ```
 
+During deep LLM check/repair, `[llm]` streams the **full reasoning chain** — how it thinks
+(full CoT text), which command it decided to run (tool + complete command), and the results.
+No black box.
+
 **Layered design (why)**:
-- **Deterministic layer** (option 3): sensors + actuators — seconds, zero LLM cost, runs even
+- **Deterministic layer** (option 2): sensors + actuators — seconds, zero LLM cost, runs even
   when everything is broken; covers known config faults (relinks / plugin deps / launcher /
   sessions / LLM credentials); skips repair automatically when the diagnosis is all green
-- **LLM brain** (option 2): a one-shot `dsh --profile headless` agent reads the report + logs
+- **LLM brain** (options 3/4): a one-shot `dsh --profile headless` agent reads the report + logs
   and reasons about the root cause — it can find/fix what deterministic rules cannot (DSH core
   incompatibility, a plugin that scrambled its config, new failure modes); headless does NOT
-  load the web's extension bundles, so extension faults don't stop it
+  load the web's extension bundles, so extension faults don't stop it; option 4 forces the deep
+  check even when the diagnosis is green
 
 **9 diagnosis checks**: web health / launcher chain / extension relinks / slot bootability /
 session file-layer (97 logs) / web.log (classified: historical vs current fault) / profile

--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 [English](README.en.md) | 中文
 
 
-> **这个仓库是 DSH 的"运维自愈工具箱"**：让 harness 在崩溃、升级、切换时都能自动恢复、
-> 无需人工干预。四个组件各管一段：
+> **为什么做这个（开发者视角）**：我在给 DSH 写插件的过程中，被三个"不方便"反复折磨，
+> 这个仓库就是这些痛点的解药：
+>
+> 1. **每天官方发新快照，升级像走钢丝** —— agent 自动做 A/B 切换：旧插件先迁移过去、
+>    构建 + 验收全过才原子切换，出问题一条命令回滚，旧版本永远兜底。
+> 2. **开发时频繁重启，改一次断一次** —— 插件 host 端不支持热加载，改完必重启，重启后
+>    agent 就断了。现在守护自动拉起 web，agent 从被打断的地方自动续接，**无人值守继续干活**。
+> 3. **web 彻底挂了的时候** —— A/B 都起不来、GUI 和 agent 全不可用（agent 跑在 web 里，
+>    web 挂 = 没有 agent 帮我）。终端一条命令 `dsh-doctor`：诊断 → 机械修复已知配置问题 →
+>    或让 LLM 深度检测修复（完整思维链实时展示）→ 把 web 拉回来。
+>
+> **组件**（自愈 + 版本轮换的完整拼图）：
 >
 > | 组件 | 类型 | 管什么 |
 > |---|---|---|
@@ -69,21 +79,27 @@ dsh-doctor                    # 交互菜单（默认英文，菜单里选 5 切
   web(:3080): ✅ healthy                  // 当前 web: ✅ 正常
 ==============================================================
   1) Quick check (diagnose only)          // 快速体检（只读）
-  2) LLM auto-repair (recommended)        // 大模型自动修复（推荐）：LLM 读诊断+日志
-                                          //   推理根因，发现/修复任意插件问题
-  3) Fix config issues (mechanical)      // 修复配置问题（机械，不依赖 LLM）：relink/
+  2) Fix config issues (mechanical)      // 修复配置问题（机械，不依赖 LLM）：relink/
      incl. relaunch web                  //   插件依赖/launcher/session/LLM 凭据等
                                           //   已知配置故障
-  4) Exit                                 // 退出
-  5) Switch language 中文                 // 切换语言
+  3) LLM repair (recommended)            // LLM 修复（推荐）：LLM 读诊断+日志推理根因，
+                                          //   发现/修复任意插件问题（含核心不兼容、
+                                          //   插件配置被改乱）
+  4) Deep LLM check & repair (always)   // LLM 深度检测和修复（每次都跑，不因诊断
+                                          //   全绿跳过；完整思维链实时展示）
+  5) Exit                                 // 退出
+  6) Switch language 中文                 // 切换语言
 ```
 
+**LLM 深度检测/修复时**，`[llm]` 流式输出**完整思维链**——它怎么想（推理全文）、决定跑什么
+命令（工具 + 完整命令）、得到什么结果，全程可见，不是黑盒。
+
 **分层设计**（为什么这样）：
-- **确定性层**（菜单 3）：传感器+执行器——秒级、零 LLM 成本、web 挂得再彻底也能跑；
+- **确定性层**（菜单 2）：传感器+执行器——秒级、零 LLM 成本、web 挂得再彻底也能跑；
   覆盖已知配置故障（relink/插件依赖/launcher/session/LLM 凭据）；诊断全绿时自动跳过修复
-- **LLM 大脑**（菜单 2）：`dsh --profile headless` 起 one-shot agent，读报告+日志推理根因，
+- **LLM 大脑**（菜单 3/4）：`dsh --profile headless` 起 one-shot agent，读报告+日志推理根因，
   **能发现/修复确定性规则想不到的问题**（DSH 核心不兼容改动、插件配置被改乱、新故障模式）；
-  headless 不加载 web 的扩展 bundle，所以扩展故障不影响它
+  headless 不加载 web 的扩展 bundle，所以扩展故障不影响它；菜单 4 强制深度检测（全绿也跑）
 
 **诊断 9 项**：web 健康 / launcher 链 / 扩展 relink / 槽可启动 / session 文件层（97 个日志）/
 web.log（分类历史残留 vs 当前故障）/ profile bundles 依赖（任意插件）/ LLM 配置（.env key）/

--- a/skills/dsh-snapshot-ab/references/postmortem-ab-switch-20260811.md
+++ b/skills/dsh-snapshot-ab/references/postmortem-ab-switch-20260811.md
@@ -94,3 +94,19 @@
 1. **验收必须走生产等价路径**：冒烟/启动类 gate 一律用与生产相同的解析环境（纯 node ESM + node_modules），禁止用 tsx/tsconfig paths 这类"更宽容"的路径做唯一验证——宽容的路径只能作为兜底，不能作为 gate。**确认（confirm）同样必须基于生产验收。**
 2. **依赖清单三处必须一致**：扩展新增 `@deepseek-ai/*` 依赖时，tsconfig paths、vitest alias、ab-config relink **三处同改**。`ext_check_runtime_deps` 会在漏改 relink 时拦下 prepare。
 3. **"绕过"不是修复**：任何"某条路径起不来就换条路径"的修复，必须同时检查那条路径本身（如 launcher 链 `dsh --version`）是否对用户/guard 可用。
+
+---
+
+## 后续（2026-08-12 补）：同一个问题两次复发，催生了 out-of-band doctor
+
+1. **dsh-llm 链接当天夜里又被外部清理**（20:44–22:52）：手工 `ln` 的链接是无主资产，
+   不在任何管理机制内，被碰 `node_modules/@deepseek-ai/` 的操作清掉后**无任何机制发现**，
+   直到用户手动 `dsh web` 再挂一次（22:52）——**同一个病，第二次发作**。
+2. **6 个旧会话打不开**（0810 时期 dsh-track 写进 session 的自定义事件，0811 白名单不认，
+   `SessionFormatUnsupportedError`）。
+3. 现场修复每一步（查 session 尾部 → 找根因 → 修 relink → 修会话 → 拉起 web）**都能脚本化**，
+   且 **agent 跑在 web 里，web 挂 = 没有 agent 能帮我**——于是做了 out-of-band 的
+   **`dsh-web-doctor`**（`dsh-doctor` 一条命令：诊断 9 项 → 机械修复配置 → LLM 深度检测修复
+   [完整思维链实时展示] → 拉起 web），并给 ab.sh 加了 **relink 自愈**（status/verify/confirm/
+   restart 每次校验并自动重建缺失链接）。动机与完整事故链：
+   `docs/web-doctor-motivation.md`。


### PR DESCRIPTION
- README (bilingual): top intro in the developer's own voice — three recurring pains (daily snapshot upgrades, restart-every-edit, total web outage) and how the repo fixes each; doctor menu block updated to the 4-item order + full-CoT streaming.
- postmortem-ab-switch-20260811.md: follow-up — dsh-llm link wiped again the same night (unowned), 6 sessions unreadable, every recovery step scriptable + agent lives inside web => motivated out-of-band dsh-web-doctor + relink self-heal.
- GitHub repo description updated (developer voice, 3 points).