### PR TITLE
chore: ignore nested .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules/
 # plugin build artifacts
 plugins/*/lib/
 plugins/*/node_modules/
+
+# nested git worktrees (inside the workspace sandbox root)
+.worktrees/


### PR DESCRIPTION
Worktrees now live under the repo root (AGENTS.md L5: .worktrees/ inside the workspace sandbox root), so the main checkout must ignore that directory to keep git status clean.