### PR TITLE
fix(restart-recover): migrate bare cordis import to @deepseek-ai/cordis

### DIFF
--- a/plugins/dsh-restart-recover/src/index.ts
+++ b/plugins/dsh-restart-recover/src/index.ts
@@ -22,7 +22,7 @@
  * @module @deepseek-ai/dsh-restart-recover
  */
 
-import type { Context } from 'cordis'
+import type { Context } from '@deepseek-ai/cordis'
 import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 

--- a/plugins/dsh-restart-recover/tsconfig.json
+++ b/plugins/dsh-restart-recover/tsconfig.json
@@ -17,7 +17,7 @@
       "/Users/chris/.dsh/source/slot-b/apps/web/node_modules/@types"
     ],
     "paths": {
-      "cordis": [
+      "@deepseek-ai/cordis": [
         "/Users/chris/.dsh/source/slot-b/vendor/cordis/lib/types/index.d.ts"
       ],
       "@deepseek-ai/dsh-agent": [

--- a/plugins/dsh-restart-recover/vitest.config.ts
+++ b/plugins/dsh-restart-recover/vitest.config.ts
@@ -11,7 +11,7 @@ const DSH = process.env.DSH_SOURCE ?? '/Users/chris/.dsh/source/current'
 export default defineConfig({
   resolve: {
     alias: [
-      { find: 'cordis', replacement: fileURLToPath(new URL(`${DSH}/vendor/cordis/lib/index.js`, import.meta.url)) },
+      { find: '@deepseek-ai/cordis', replacement: fileURLToPath(new URL(`${DSH}/vendor/cordis/lib/index.js`, import.meta.url)) },
       { find: '@deepseek-ai/dsh-agent', replacement: fileURLToPath(new URL(`${DSH}/packages/core/agent/lib/index.js`, import.meta.url)) },
       { find: '@deepseek-ai/dsh-session', replacement: fileURLToPath(new URL(`${DSH}/packages/core/session/lib/index.js`, import.meta.url)) },
     ],


### PR DESCRIPTION
## 为什么

final 发布（snapshots/20260812T172954Z-final-unwatermarked）与 0811 快照一样，所有 Context 增强挂在 `declare module '@deepseek-ai/cordis'`，一方源码全部 scoped 导入。dsh-restart-recover 是最后一个仍用裸 `from 'cordis'` 的插件（type-only，运行时无碍，但 tsconfig paths / vitest alias 都要跟着对齐）。

## 改了什么

- `src/index.ts`：`import type { Context } from 'cordis'` → `'@deepseek-ai/cordis'`
- `tsconfig.json`：paths 键 `"cordis"` → `"@deepseek-ai/cordis"`
- `vitest.config.ts`：alias `find: 'cordis'` → `'@deepseek-ai/cordis'`

## 验收

- `tsc -p tsconfig.json --noEmit` 干净；`vitest run tests` **9/9 过**（对 slot-b 类型，cordis 4.0.1-rc.1 与 final 一致）。
- lib 已重建（gitignored，主目录合并后按 L5 再 build 一次即可）。
