### PR TITLE
fix(snapshot-ab): ext_check_runtime_deps skips client bundle chunks too

### DIFF
--- a/skills/dsh-snapshot-ab/scripts/lib/extension.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/extension.sh
@@ -106,8 +106,9 @@ ext_install_skills() {
 #   ERR_MODULE_NOT_FOUND after cutover (2026-08-11 dsh-llm incident: import was
 #   added in the extension, tsconfig/vitest already listed it, ab-config.relink
 #   did not). Scan the built lib for bare specifiers and fail the prepare with a
-#   precise missing-link list. lib/client.js is excluded: the client bundle is
-#   injected by the profile pnpm closure, not the relink map.
+#   precise missing-link list. lib/client.js AND its chunk dir lib/client/ are
+#   excluded: the client bundle is injected by the profile pnpm closure, not the
+#   relink map (chunks would otherwise false-positive on client-only imports).
 ext_check_runtime_deps() {
   local ext="$1" cand="$2" repo="$3"
   local name libdir
@@ -125,7 +126,9 @@ pat2 = re.compile(r"""import\s*\(\s*['"]([^'"]+)['"]\s*\)""")
 seen = set()
 for base, _dirs, files in os.walk(root):
     for f in files:
-        if not f.endswith(".js") or f == "client.js":
+        # skip the whole client bundle (lib/client.js + lib/client/ chunks):
+        # browser code is injected by the profile pnpm closure, not relinks
+        if not f.endswith(".js") or f == "client.js" or "/client/" in base or base.endswith("/client"):
             continue
         if "/types/" in base or base.endswith("/types"):
             continue


### PR DESCRIPTION
## 为什么

2026-08-11 事故后新增的 `ext_check_runtime_deps` gate（PR #10）只排除了 `lib/client.js` 单文件，没排除 client bundle 分块目录（`lib/client/`）。dsh-track 的 client 包是拆分的（`lib/client/right-panel.js` 等），其中对 `@deepseek-ai/dsh-client-runtime/client` 的**值导入**被 gate 误报为「运行时依赖漏链」——而 client 侧导入本就由 profile pnpm 闭包提供、不经 relink（与 gate 文档声明的意图一致）。结果 final 的 prepare 被误拦。

## 改了什么

- `ext_check_runtime_deps` 扫描跳过整个 client bundle 区：`f == "client.js"` 之外，任何 base 含 `/client/` 或以 `/client` 结尾的文件也跳过。

## 验收

- patched 扫描对 dsh-involute/lib：只剩 `@deepseek-ai/dsh-llm`、`@deepseek-ai/dsh-tools`（均在 relink 清单）✓；client 分块误报消失。
- `ab.sh prepare --slot b`（final）应可继续到冒烟。
