### PR TITLE
chore: npm keywords — dsh-plugin discoverability

### DIFF
--- a/plugins/dsh-restart-recover/package.json
+++ b/plugins/dsh-restart-recover/package.json
@@ -32,5 +32,15 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "dsh",
+    "deepseek-harness",
+    "dsh-plugin",
+    "dsh-bundle",
+    "restart",
+    "self-heal",
+    "recovery",
+    "plugin"
+  ]
 }


### PR DESCRIPTION
Add npm `keywords` (incl. `dsh-plugin`) to plugins/dsh-restart-recover for registry discoverability.