### PR TITLE
chore: untrack stale node_modules symlink (should be gitignored)

### DIFF
--- a/plugins/dsh-restart-recover/node_modules
+++ b/plugins/dsh-restart-recover/node_modules
@@ -1,1 +1,0 @@
-/Users/chris/source/dsh-skill-snapshot-ab/plugins/dsh-restart-recover/node_modules


### PR DESCRIPTION
plugins/dsh-restart-recover/node_modules was committed as a symlink (index mode 120000) despite .gitignore; it broke npm pack (spawn ELOOP self-loop) and blocks pulls. Untrack it; the dir is regenerable dev tooling (relinked from the DSH slot).