### PR TITLE
fix: back to @deepseek-ai/dsh-restart-recover name until @fakechris is published

### DIFF
--- a/docs/RELEASE.en.md
+++ b/docs/RELEASE.en.md
@@ -38,7 +38,7 @@ dsh plugin --profile web add ./pkg-0.1.0.tgz        # pnpm pack tarball
 **Live verification** (this machine, 2026-08-12): `dsh plugin --profile demo add .`
 auto-initialized the profile, `pnpm link`ed the plugin, appended the bundle to
 `dsh.profile.bundles`; `dsh --profile demo --dump-config` showed the
-`# == @fakechris/dsh-restart-recover` layer. The production `web` profile already
+`# == @deepseek-ai/dsh-restart-recover` layer. The production `web` profile already
 follows this mechanism (bundles: `dsh-base / dsh-web-app / dsh-track / dsh-restart-recover`).
 
 ### 1.3 The git-install "build-script catch" (official wording)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -31,7 +31,7 @@ dsh plugin --profile web add ./pkg-0.1.0.tgz        # pnpm pack 的 tarball
 
 **实测验证**（本机 2026-08-12）：`dsh plugin --profile demo add .` 自动初始化 profile、
 `pnpm link` 插件、把 bundle 追加进 `dsh.profile.bundles`；`dsh --profile demo --dump-config`
-显示 `# == @fakechris/dsh-restart-recover` 层。生产 `web` profile 已按此机制管理
+显示 `# == @deepseek-ai/dsh-restart-recover` 层。生产 `web` profile 已按此机制管理
 （bundles: `dsh-base / dsh-web-app / dsh-track / dsh-restart-recover`）。
 
 ### 1.3 git 直装的"构建脚本陷阱"（官方原文 "the build-script catch"）
@@ -132,12 +132,12 @@ bash skills/dsh-web-guard/scripts/install.sh   # 可选：自愈守护
 ### 结论（2026-08-13 更新）：bundle 包已迁 `@fakechris` scope、可发 npm；skills 仍是目录机制。
 
 > 更新：用户拥有 `@fakechris` / `@turnkeyai` 两个 npm scope。`plugins/dsh-restart-recover`
-> 已改名为 `@fakechris/dsh-restart-recover` + `publishConfig.access=public`，`npm pack`
+> 已改名为 `@deepseek-ai/dsh-restart-recover` + `publishConfig.access=public`，`npm pack`
 > 验证通过（lib + cordis.patch.yml），发布命令：
 > ```sh
 > cd plugins/dsh-restart-recover && npm publish --registry=https://registry.npmjs.org
 > ```
-> 消费端：`dsh plugin --profile web add @fakechris/dsh-restart-recover`（npm 预构建，无需
+> 消费端：`dsh plugin --profile web add @deepseek-ai/dsh-restart-recover`（npm 预构建，无需
 > allowBuilds）。skills（dsh-snapshot-ab / dsh-web-guard / dsh-session-recovery / dsh-web-doctor）
 > 仍是 `~/.dsh/skills/` 目录机制，不进 npm，走 `bash scripts/install.sh`。
 

--- a/plugins/dsh-restart-recover/cordis.patch.yml
+++ b/plugins/dsh-restart-recover/cordis.patch.yml
@@ -2,8 +2,8 @@
 #
 # Install into a profile with:
 #   dsh plugin --profile web add github:dsh-external/dsh-restart-recover
-# (or: add "@fakechris/dsh-restart-recover" to the profile's dsh.profile.bundles)
+# (or: add "@deepseek-ai/dsh-restart-recover" to the profile's dsh.profile.bundles)
 
 - insert:
     - id: restart-recover
-      name: '@fakechris/dsh-restart-recover'
+      name: '@deepseek-ai/dsh-restart-recover'

--- a/plugins/dsh-restart-recover/package.json
+++ b/plugins/dsh-restart-recover/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fakechris/dsh-restart-recover",
+  "name": "@deepseek-ai/dsh-restart-recover",
   "description": "Restart recovery for dsh web: after a crash/restart, an interrupted agent turn continues automatically (host-side agent/created listener — no browser timing races). Pairs with the dsh-web-guard skill (which auto-relaunches the web process); together they make restart self-healing.",
   "version": "0.2.1",
   "private": true,
@@ -30,9 +30,6 @@
     "src",
     "cordis.patch.yml"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "keywords": [
     "dsh",
     "deepseek-harness",

--- a/plugins/dsh-restart-recover/src/index.ts
+++ b/plugins/dsh-restart-recover/src/index.ts
@@ -19,14 +19,14 @@
  *
  * Pairs with the dsh-web-guard skill: the guard auto-relaunches the web
  * process (launchd/systemd), this plugin continues the interrupted turn.
- * @module @fakechris/dsh-restart-recover
+ * @module @deepseek-ai/dsh-restart-recover
  */
 
 import type { Context } from '@deepseek-ai/cordis'
 import type { Agent } from '@deepseek-ai/dsh-agent'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 
-export const name = '@fakechris/dsh-restart-recover'
+export const name = '@deepseek-ai/dsh-restart-recover'
 
 /** Plugin configuration. */
 export interface Config {
@@ -89,7 +89,7 @@ export function apply(ctx: Context, config?: Config): void {
         id: `resume-${Math.random().toString(36).slice(2, 10)}`,
         role: 'user' as const,
         content: [{ type: 'text' as const, text: CONTINUE_MESSAGE }],
-        source: { kind: 'plugin' as const, plugin: '@fakechris/dsh-restart-recover' },
+        source: { kind: 'plugin' as const, plugin: '@deepseek-ai/dsh-restart-recover' },
       }
       agent.followup(msg as never)
       // The follow-up is durable in the session log via the agent loop.

--- a/skills/dsh-web-guard/SKILL.md
+++ b/skills/dsh-web-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-web-guard
-description: "dsh web 自愈——重启自动拉起 + 自动继续。agent 运行在 dsh web 进程内，kill 掉 3080 等于杀掉自己，无法自救。本 skill 提供完整的重启自愈：① 守护（scripts/install.sh 装成系统服务，launchd/systemd，PPID=1）在 web 死后 10 秒内自动拉起；② 配套插件 @fakechris/dsh-restart-recover（本项目的 plugins/ 目录）监听 agent/created，检测到上次 turn 被中断后自动注入续接消息，agent 带着中断上下文继续 —— 用户零输入。当用户说\"重启 3080 / web 挂了怎么自动拉起来 / 切换后自己把自己拉起来 / kill 后不用手动启动 / 重启后自动继续 / 做重启守护\"时使用 English: self-healing restart for dsh web — auto-restart when web dies (launchd/systemd guard) plus auto-continue of the interrupted turn; use when the user says \"restart 3080\", \"web is down, bring it back\", \"restart after switchover\", \"no manual start after kill\", \"auto-continue after restart\", or \"make a restart guard\"。"
+description: "dsh web 自愈——重启自动拉起 + 自动继续。agent 运行在 dsh web 进程内，kill 掉 3080 等于杀掉自己，无法自救。本 skill 提供完整的重启自愈：① 守护（scripts/install.sh 装成系统服务，launchd/systemd，PPID=1）在 web 死后 10 秒内自动拉起；② 配套插件 @deepseek-ai/dsh-restart-recover（本项目的 plugins/ 目录）监听 agent/created，检测到上次 turn 被中断后自动注入续接消息，agent 带着中断上下文继续 —— 用户零输入。当用户说\"重启 3080 / web 挂了怎么自动拉起来 / 切换后自己把自己拉起来 / kill 后不用手动启动 / 重启后自动继续 / 做重启守护\"时使用 English: self-healing restart for dsh web — auto-restart when web dies (launchd/systemd guard) plus auto-continue of the interrupted turn; use when the user says \"restart 3080\", \"web is down, bring it back\", \"restart after switchover\", \"no manual start after kill\", \"auto-continue after restart\", or \"make a restart guard\"。"
 ---
 
 # dsh-web-guard — dsh web 自愈（守护拉起 + 自动续接）


### PR DESCRIPTION
Runtime name must match the profile declaration (@deepseek-ai/dsh-restart-recover) until the @fakechris package is actually published.