### PR TITLE
fix(web-doctor): TUI i18n — CJK input/editing + wide-char rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Each entry links its squash-merged PR.
 
 ## [Unreleased]
 
+- `fix(web-doctor)`: TUI i18n + input editing — Chinese (CJK) input & editing
+  works: UTF-8 locale set before curses (get_wch returned CJK byte-wise
+  before), wide-char column math (display_width/trunc_width) so CJK renders
+  and cursor/cutoff never misalign, manual ESC-sequence parsing (macOS ncurses
+  delivers `ESC[D` as separate chars even with keypad on — arrows were read as
+  ESC and the old handler WIPED the input), input cursor editing (←/→/Home/
+  End move, ⌫/Delete delete at cursor, insert at cursor), and lone ESC is a
+  no-op instead of clearing the message.
+
+
 - `feat(web-doctor)`: mini TUI guided mode (`dsh-doctor --guide` / menu 7) — a
   REAL full-screen interactive TUI (python3+curses, stdlib only). The
   deterministic diagnosis STREAMS into the plain terminal first (no black

--- a/skills/dsh-web-doctor/scripts/doctor-tui.py
+++ b/skills/dsh-web-doctor/scripts/doctor-tui.py
@@ -27,13 +27,41 @@ rest of the doctor uses (zstd/curl/node). No pip packages.
 
 import curses
 import json
+import locale
 import os
 import re
 import shutil
 import subprocess
 import sys
 import time
+import unicodedata
 from collections import deque
+
+
+def display_width(s):
+    """Terminal column width: wide/fullwidth chars (CJK) take 2 columns."""
+    w = 0
+    for ch in s:
+        if unicodedata.combining(ch):
+            continue
+        if unicodedata.east_asian_width(ch) in ("W", "F"):
+            w += 2
+        else:
+            w += 1
+    return w
+
+
+def trunc_width(s, maxw):
+    """Cut s to at most maxw terminal columns, never splitting a wide char."""
+    out = []
+    w = 0
+    for ch in s:
+        cw = display_width(ch)
+        if w + cw > maxw:
+            break
+        out.append(ch)
+        w += cw
+    return "".join(out)
 
 HOME = os.path.expanduser("~")
 SKILLS_DIR = os.environ.get("DSH_SKILLS_DIR", os.path.join(HOME, ".dsh", "skills"))
@@ -199,6 +227,7 @@ class Tui:
         self.scroll = 0
         self.follow = True   # auto-follow bottom; manual scroll disables
         self.input = ""
+        self.cursor = 0      # insertion point inside self.input (char index)
         self.msg = ""
         self.phase = "diag"      # diag | fix | llm | restart | done
         self.problems = []
@@ -357,13 +386,13 @@ class Tui:
             "current:" + self._current_slot(), self._keys_hint(),
         )
         try:
-            scr.addstr(0, 0, status[: w - 1], curses.A_REVERSE)
+            scr.addstr(0, 0, trunc_width(status, w - 1), curses.A_REVERSE)
         except curses.error:
             pass
         # message line (2nd from bottom)
         if self.msg:
             try:
-                scr.addstr(h - 2, 0, " " + self.msg[: w - 2], self.attr_for("warn"))
+                scr.addstr(h - 2, 0, trunc_width(" " + self.msg, w - 2), self.attr_for("warn"))
             except curses.error:
                 pass
         # content pane
@@ -392,13 +421,14 @@ class Tui:
                         scr.addstr(top + i, x, ch, attr)
                     except curses.error:
                         pass
-                    x += 1
-        # input bar
+                    x += display_width(ch)   # wide chars (CJK) take 2 columns
+        # input bar (cursor column accounts for wide chars + insertion point)
         label = self._input_label()
         prompt = label + self.input
+        curs_col = display_width(label) + display_width(self.input[:self.cursor])
         try:
-            scr.addstr(h - 1, 0, prompt[: w - 2], self.attr_for("user"))
-            scr.move(h - 1, min(len(prompt), w - 2))
+            scr.addstr(h - 1, 0, trunc_width(prompt, w - 2), self.attr_for("user"))
+            scr.move(h - 1, min(curs_col, w - 2))
         except curses.error:
             pass
         scr.refresh()
@@ -551,27 +581,27 @@ class Tui:
         self.add("press q or Ctrl-C to exit   // 按 q 或 Ctrl-C 退出", "dim")
 
     # ---- input -------------------------------------------------------------
-    def _read_input(self):
-        """Blocking input for fix/restart prompts. Returns answer or None (quit)."""
-        while True:
-            self.draw()
-            ch = self._getch(None)
-            if ch is None:
-                continue
-            if ch == "KEY_ENTER":
-                ans = self.input
-                self.input = ""
-                return ans
-            if ch in ("KEY_QUIT", "KEY_CTRL_C"):
-                return None
-            if ch == "KEY_ESC":
-                self.input = ""
-                continue
-            if ch in ("KEY_BACKSPACE",):
-                self.input = self.input[:-1]
-                continue
-            if len(ch) == 1:
-                self.input += ch
+    def _read_esc_sequence(self):
+        """macOS ncurses delivers ESC[<X> as SEPARATE chars even with keypad on
+        (verified 2026-08-13) — combine them here so ←/→/Home/End work, and a
+        lone ESC no longer arrives as a stray char that clears the input."""
+        esc_map = {"A": "KEY_UP", "B": "KEY_DOWN", "C": "KEY_RIGHT",
+                   "D": "KEY_LEFT", "H": "KEY_HOME", "F": "KEY_END"}
+        try:
+            self.scr.timeout(60)   # short window for the rest of the sequence
+            nxt = self.scr.get_wch()
+        except curses.error:
+            return "KEY_ESC"       # lone ESC
+        if not isinstance(nxt, str) or nxt not in ("[", "O"):
+            return "KEY_ESC"
+        try:
+            self.scr.timeout(60)
+            final = self.scr.get_wch()
+        except curses.error:
+            return "KEY_ESC"
+        if isinstance(final, str) and final in esc_map:
+            return esc_map[final]
+        return "KEY_ESC"
 
     def _getch(self, timeout):
         self.scr.timeout(timeout if timeout is not None else -1)
@@ -587,7 +617,7 @@ class Tui:
             if ch == "\x03":
                 return "KEY_CTRL_C"
             if ch == "\x1b":
-                return "KEY_ESC"
+                return self._read_esc_sequence()
             if ch in ("\x7f", "\x08"):
                 return "KEY_BACKSPACE"
             if ch == "\x0c":
@@ -601,6 +631,9 @@ class Tui:
             curses.KEY_NPAGE: "KEY_NPAGE",
             curses.KEY_HOME: "KEY_HOME",
             curses.KEY_END: "KEY_END",
+            curses.KEY_LEFT: "KEY_LEFT",
+            curses.KEY_RIGHT: "KEY_RIGHT",
+            curses.KEY_DC: "KEY_DC",
             curses.KEY_BACKSPACE: "KEY_BACKSPACE",
             curses.KEY_RESIZE: "KEY_RESIZE",
         }.get(ch, "KEY_OTHER")
@@ -628,28 +661,45 @@ class Tui:
             self.follow = False
             self.scroll += 10
             return
+        # HOME/END edit the INPUT cursor (the input bar is the focus; pane
+        # scrolling is PgUp/PgDn, End-to-bottom is the default follow mode)
+        if ch == "KEY_BACKSPACE":
+            if self.cursor > 0:
+                self.input = self.input[:self.cursor - 1] + self.input[self.cursor:]
+                self.cursor -= 1
+            return
+        if ch == "KEY_DC":
+            if self.cursor < len(self.input):
+                self.input = self.input[:self.cursor] + self.input[self.cursor + 1:]
+            return
+        if ch == "KEY_LEFT":
+            if self.cursor > 0:
+                self.cursor -= 1
+            return
+        if ch == "KEY_RIGHT":
+            if self.cursor < len(self.input):
+                self.cursor += 1
+            return
         if ch == "KEY_HOME":
-            self.follow = False
-            self.scroll = 0
+            self.cursor = 0
             return
         if ch == "KEY_END":
-            self.follow = True
-            return
-        if ch == "KEY_BACKSPACE":
-            self.input = self.input[:-1]
+            self.cursor = len(self.input)
             return
         if ch == "KEY_ENTER":
             self._submit()
             return
         if ch == "KEY_ESC":
-            self.input = ""
-            return
-        if isinstance(ch, str) and len(ch) == 1:
-            self.input += ch
+            return   # lone ESC: no-op — never wipe the typed message
+        if isinstance(ch, str) and len(ch) >= 1:
+            # insert at the cursor (unicode-safe: CJK arrives as one char)
+            self.input = self.input[:self.cursor] + ch + self.input[self.cursor:]
+            self.cursor += 1
 
     def _submit(self):
         text = self.input.strip()
         self.input = ""
+        self.cursor = 0
         if not text:
             return
         if text == "/quit" or text == "/q":
@@ -665,6 +715,8 @@ class Tui:
     def _show_help(self):
         self.add("── keys ──", "heading")
         self.add("  type + Enter        send a message to the agent   // 输入后回车发送给 LLM", "plain")
+        self.add("  ←/→ Home/End        move the input cursor (edit mid-text)  // 移动输入光标", "plain")
+        self.add("  ⌫ / Delete          delete before/after the cursor", "plain")
         self.add("  Ctrl-C              interrupt a running agent (or quit when idle)", "plain")
         self.add("  PgUp/PgDn/Home/End  scroll the pane", "plain")
         self.add("  Ctrl-L              clear the pane", "plain")
@@ -730,6 +782,12 @@ class Tui:
 
 # ---------------------------------------------------------------------------
 def main(scr, problems_json=None):
+    # UTF-8 locale first — without it curses reads CJK input byte-wise and
+    # wide-char rendering misaligns (2026-08-13: Chinese input/editing broke)
+    try:
+        locale.setlocale(locale.LC_ALL, "")
+    except Exception:
+        pass
     # raw mode: Ctrl-C arrives as a character through get_wch, NOT as SIGINT
     # to the whole foreground process group — so it interrupts the agent
     # (agent.kill), not the TUI itself. cbreak (the wrapper default) keeps


### PR DESCRIPTION
## 中文输入/编辑修复（2026-08-13）

用户反馈：ncurses 输入对中文支持有问题，前后编辑有问题。定位到 4 个根因并修复：

1. **没设 UTF-8 locale** → curses `get_wch` 把中文按字节返回、宽字符渲染错位；`main()` 开头 `locale.setlocale(LC_ALL, '')`
2. **没有宽字符列宽计算** → pane/状态栏/消息/输入条把中文按 1 列渲染、按字符数截断会把中文切半；新增 `display_width()`/`trunc_width()`（east_asian_width，combining 安全）并全处使用
3. **macOS ncurses 不组合 ESC 序列**（pty 实测：即使 keypad on，`ESC[D` 也按 `ESC` `[` `D` 三个字符到达）→ 方向键被读成 ESC，而旧 `KEY_ESC` 处理会**清空整个已输入消息**；`_getch` 里手动组合 `ESC[ A/B/C/D/H/F` 和 `ESC O …`，且单独 ESC 变成 no-op（绝不清输入）
4. **没有行内编辑**：输入条只能末尾追加/删尾；新增光标（字符索引）——←/→/Home/End 移动、⌫/Delete 删光标处、输入插入光标处（unicode 安全）

## 验收
- 编辑单元测试全过：ASCII、中文、宽字符中间插入（8 个中文字符宽度=16 列）
- pty 实测：输入 `你好世界` → ←← → 插入 `美丽` → 回车 → pane 显示编辑后的 **`你好美丽世界`**
- 全绿/故障 fake 环境全流程回归全 PASS