### PR TITLE
docs(release): example bumps to the NEXT version (v0.3.1)

### DIFF
--- a/docs/RELEASE.en.md
+++ b/docs/RELEASE.en.md
@@ -127,10 +127,10 @@ git-install requirement. Skills need no build.
 ```sh
 # 1) Changes go through PRs (squash merge, AGENTS.md L4)
 # 2) After merge: bump version + update CHANGELOG
-echo "0.3.0" > VERSION
+echo "0.3.1" > VERSION
 # 3) Tag and ship
-git add VERSION CHANGELOG.md && git commit -m "chore(release): v0.3.0"
-git tag v0.3.0 && git push origin main --tags
+git add VERSION CHANGELOG.md && git commit -m "chore(release): v0.3.1"
+git tag v0.3.1 && git push origin main --tags
 # 4) Consumers update
 bash scripts/update.sh
 ```

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -107,10 +107,10 @@ bundle 插件自带 `prepare` 脚本（`node scripts/dsh-env.mjs tsc -p tsconfig
 ```sh
 # 1) 改动走 PR（squash merge，见 AGENTS.md L4）
 # 2) merge 后 bump 版本 + 更新 CHANGELOG（单独小 PR 或随最后改动）
-echo "0.3.0" > VERSION   # 或 minor/major
+echo "0.3.1" > VERSION   # 或 minor/major
 # 3) 打 tag 发布
-git add VERSION CHANGELOG.md && git commit -m "chore(release): v0.3.0"
-git tag v0.3.0 && git push origin main --tags
+git add VERSION CHANGELOG.md && git commit -m "chore(release): v0.3.1"
+git tag v0.3.1 && git push origin main --tags
 # 4) 消费端更新
 bash scripts/update.sh
 ```


### PR DESCRIPTION
v0.3.0 已发布（tag 已打）——RELEASE.md/en 发布流程示例改为下一版本 v0.3.1，避免下次照抄示例时重复打 v0.3.0 tag。纯文档。