### PR TITLE
feat(ab): npm-ecosystem A/B rotation — dist-tag upstream, npm slots

### DIFF
--- a/skills/dsh-snapshot-ab/SKILL.md
+++ b/skills/dsh-snapshot-ab/SKILL.md
@@ -1,29 +1,32 @@
 ---
 name: dsh-snapshot-ab
 description: >-
-  每日上游快照的 A/B 双槽轮换 + 官方改动提炼机制。上游官方（dsh2026/test-fakechris）每天发布新的
-  snapshots/YYYYMMDDTHHMMSSZ-* 分支：日常分析——跑当天快照与前一天快照的 diff，先读官方 changelog
-  （新增 agent notes，ab.sh notes）再验证代码，产出 snapshot-diff-report 报告；升级轮换——新快照
-  检出到另一槽、挂接扩展（dsh-track 等）、构建+验收通过后才原子切换 current，下一天角色互换。
-  用户说"分析今天和昨天的快照 / 今天官方改了啥 / 官方改了什么 / 看下今天的 changelog / 官方发新快照了吗"
-  触发日常分析；说"官方发了新 branch / 切换新快照 / 升级到今天的 snapshot / AB 双版本轮换 / 跑一下
-  daily 快照更新"触发升级轮换。English: daily upstream-snapshot A/B dual-slot rotation plus
-  an official-change digest; use when the user asks what the official side changed between today's and
-  yesterday's snapshots (run the diff, read the agent-notes changelog first), mentions a new official
-  snapshot branch, switching or upgrading to today's snapshot, AB dual-version rotation, or a daily
-  snapshot update。
+  官方 DeepSeek Harness 的 A/B 双槽轮换（npm 生态版）+ 版本检测机制。上游真相 = npm registry：
+  检测 @deepseek-ai/dsh 的 dist-tag（next/latest），新版本装进另一槽（DSH_HOME + 扩展 npm 包），
+  验收（冒烟/浏览器 e2e）通过后原子切换 current，旧版本保留回滚；也支持 --source 手动源码路径
+  （git master / 快照分支）。用户说"官方发新版了吗 / 检查 npm 更新 / 升级到最新版 / AB 双版本轮换 /
+  切换新版本 / 跑一下更新"触发；说"官方今天改了啥 / 分析版本差异"触发版本对比。English: official
+  DeepSeek Harness A/B dual-slot rotation on the npm ecosystem — npm registry dist-tags are the
+  upstream truth; a new @deepseek-ai/dsh version is installed into the other slot (DSH_HOME plus
+  extension npm packages), verified (smoke / browser e2e), then current is switched atomically with
+  the old version kept for rollback; --source offers the legacy git path. Use when the user asks to
+  check for a new official npm release, upgrade to the latest version, rotate A/B versions, or diff
+  official versions。
 ---
 
-# DSH Snapshot A/B Rotation（快照 A/B 轮换）
+# DSH A/B Rotation — npm ecosystem（npm 生态版 A/B 轮换）
 
-上游官方每天发布一个新的 snapshot 分支（`snapshots/YYYYMMDDTHHMMSSZ-<sha>`），我们不做 rebase 式升级，而是把官方快照**原样**放入一个槽，在它之上重新挂接我们的扩展，验收通过再切换。两个槽 A/B 轮流当"当前版本"，任何时刻都有一个未动的旧版本可回滚。
+官方 2026-08-13 起从私有快照转为公开仓库 + npm 发布：**npm registry 是唯一发布真相**
+（master 可能落后 npm、无 git tag）。本机制不再跟随 git 快照分支，而是检测 `@deepseek-ai/dsh`
+的 dist-tag（`next` = 最新 rc，`latest` = 正式版），把新版本装进另一个槽（独立 DSH_HOME +
+扩展 npm 包），验收通过后原子切换 `current`，旧版本保留回滚。
 
 ## 何时用
 
-- 官方发布了新快照，要把运行版本换成新的（每天例行）。
-- 需要知道官方某天快照改了什么（日常分析：changelog + diff + 影响评估）。
-- 需要评估某个快照对我们扩展（dsh-track 等）的兼容性（构建/测试/冒烟）。
-- 需要回滚到上一个快照。
+- 官方发布了新 npm 版本（dist-tag 变化），要把运行版本换成新的。
+- 需要评估某 npm 版本对我们扩展（dsh-track 等）的兼容性（安装/冒烟/e2e）。
+- 需要回滚到上一个 npm 版本。
+- （手动）`--source` 走源码路径：git master / 快照分支 + 源码构建 + 扩展 relink。
 
 不要用本 skill 做 rebase 到 master 的升级（那是 `dsh-upgrade`）、或修改 harness 源码（那是 `dsh-customize`）。
 

--- a/skills/dsh-snapshot-ab/references/ab-config.example.json
+++ b/skills/dsh-snapshot-ab/references/ab-config.example.json
@@ -1,10 +1,18 @@
 {
-  "upstream": "https://github.com/dsh2026/test-fakechris.git",
-  "snapshotRefPrefix": "refs/heads/snapshots/",
+  "upstream": "npm:@deepseek-ai/dsh",
+  "snapshotRefPrefix": "refs/heads/",
+  "snapshotBranch": "master",
   "sourcePathPrefix": "/Users/chris/.dsh/source/current",
+  "npm": {
+    "package": "@deepseek-ai/dsh",
+    "distTag": "next",
+    "registry": "https://registry.npmjs.org/",
+    "cacheDir": "/Users/chris/.dsh/npm-cache"
+  },
   "extensions": [
     {
       "name": "dsh-track",
+      "npm": "@fakechris/dsh-track",
       "repo": "/Users/chris/source/dsh-involute",
       "profile": "web",
       "skills": [
@@ -16,7 +24,8 @@
         "node_modules/@deepseek-ai/dsh-storage-json": "packages/storage/storage-json",
         "node_modules/@deepseek-ai/dsh-system-prompt": "packages/core/system-prompt",
         "node_modules/@deepseek-ai/dsh-tools": "packages/core/tools",
-        "node_modules/cordis": "vendor/cordis"
+        "node_modules/@deepseek-ai/cordis": "vendor/cordis",
+        "node_modules/@deepseek-ai/dsh-llm": "packages/llm/llm"
       },
       "tsconfig": "tsconfig.json",
       "tsconfigOut": "tsconfig.ab.json",
@@ -34,7 +43,7 @@
       "/"
     ],
     "smokeClientIds": [
-      "@deepseek-ai/dsh-track"
+      "@fakechris/dsh-track"
     ]
   },
   "acceptance": {
@@ -43,7 +52,7 @@
       "enabled": true,
       "checks": [
         {
-          "id": "@deepseek-ai/dsh-track",
+          "id": "@fakechris/dsh-track",
           "selector": "#dsh-track-fab",
           "expect": "present"
         }

--- a/skills/dsh-snapshot-ab/references/mechanism-design-npm.md
+++ b/skills/dsh-snapshot-ab/references/mechanism-design-npm.md
@@ -1,0 +1,142 @@
+# DSH 快照 A/B 轮换 — npm 生态版机制设计
+
+> 日期：2026-08-14 · 作者：dsh-snapshot-ab skill
+> 背景：官方从私有快照发布（`dsh2026/test-fakechris` snapshots/*）转为**公开正式仓库
+> （`deepseek-ai/deepseek-harness`）+ npm 发布**。本设计把 A/B 轮换从「源码快照」转型为
+> 「npm 包形态」，与官方 npm 发布节奏精确同步。
+
+---
+
+## 一、官方发布机制（已实证，2026-08-14）
+
+### 1.1 npm 是唯一发布真相
+
+- 官方发布管线：`scripts/release/`（bump → 提交 → CI pack → 发布 npm），版本号写入 git，
+  但 **npm registry 才是消费端标准**（官方 README 第一运行方式 `npx @deepseek-ai/dsh web`）。
+- **npm 领先 master**：实测 npm `0.1.0-rc.6`（2026-08-13T12:35Z）发布时，master 最新
+  release commit 是 `0.1.0-rc.5`（10:49Z）——rc.6 的 commit 尚未合并/推送 master。
+- **无 git tag**：官方 `gh api tags` 为空（Agent Note 声明的 `dsh-v<version>` tag 未实际创建）。
+- 结论：**跟随 npm dist-tag，不能跟随 git master**。
+
+### 1.2 dist-tag 语义（官方 publish 规则）
+
+- prerelease 版本（如 `0.1.0-rc.6`）→ `--tag next`
+- 正式版（如 `0.1.0`）→ `--tag latest`
+- 消费侧：日常用 `next`（最新 rc），正式发布后切 `latest`。
+
+### 1.3 消费形态（官方 README + 生态）
+
+- 官方包 `@deepseek-ai/dsh`（元包）→ `npx @deepseek-ai/dsh web`
+- 生态扩展（我们的 dsh-track）→ npm 包 `@fakechris/dsh-track` → `dsh plugin add`
+- 官方 `@deepseek-ai/*` 子包（dsh-session/dsh-tools/dsh-llm/cordis…）全部在 npm，profile 闭包注入。
+
+---
+
+## 二、转型：源码槽 → npm 包槽
+
+### 2.1 为什么不能保留源码槽
+
+| 维度 | 源码槽（旧） | npm 包槽（新） |
+|---|---|---|
+| 内容来源 | git 快照分支 / master | npm tarball（`@deepseek-ai/dsh@<ver>` + 闭包） |
+| 版本对应 | master 落后 npm，无 tag | **精确对应 npm 版本** |
+| 构建 | 需 pnpm install + build:lib + build:web | **即装即用**（npm 包已编译） |
+| 扩展挂接 | relink node_modules → 槽源码 packages/ | 扩展 npm 包装入 profile |
+| 验收 | staging 起 lib/bin.js + 冒烟 | 同左（profile 声明换成 npm 包） |
+
+### 2.2 新布局
+
+```
+~/.dsh/source/current          符号链接 → 生效槽（保留，语义不变）
+~/.dsh/source/slot-a/          槽 = 独立 DSH_HOME（profiles/ + node_modules）
+  └── profiles/web/            bundles: @deepseek-ai/dsh-base + dsh-web-app + <ext-npm 包>
+~/.dsh/source/slot-b/          另一版本（回滚点）
+~/.dsh/npm-cache/              npm pack 缓存（tarball，避免重复下载）
+```
+
+- 槽不再是 git worktree，是**两个隔离的 DSH_HOME 目录**，各装一个 npm 版本。
+- `current` 符号链接语义不变：切换 = 原子 `ln -sfn`。
+- launcher：`~/.local/bin/dsh → current/bin/dsh`（槽内生成 wrapper → npm 闭包 bin.js）。
+
+### 2.3 扩展挂接（npm 形态）
+
+- ab-config `extensions[].npm`（如 `@fakechris/dsh-track`）→ prepare 时 `pnpm add` 进候选槽 profile。
+- 兼容：`--source` 手动路径仍走**源码 relink**（保留旧 extension.sh 逻辑）。
+
+---
+
+## 三、命令改造
+
+### 3.1 discover — npm dist-tag 检测
+
+```
+ab.sh discover
+  → npm view @deepseek-ai/dsh dist-tags   # next / latest
+  → 对比 current 槽版本
+  → 有更新：打印候选版本 + 变更摘要（npm 无 changelog，展示版本号 + 发布时间）
+  → 无更新：up to date
+```
+
+### 3.2 prepare — 双模式
+
+```
+ab.sh prepare [--source <ref>]   # 默认 npm；--source 走源码
+  npm 模式：
+    → npm pack @deepseek-ai/dsh@<version> 到缓存
+    → 解压为候选槽 DSH_HOME（profiles/web + 依赖闭包）
+    → 扩展：pnpm add @fakechris/<ext>@<ver>（extensions[].npm）
+    → 槽 launcher 生成（current/bin/dsh → npm bin）
+    → staging 冒烟（HTTP 200 + client manifest + e2e）
+  source 模式：
+    → 保留旧逻辑：checkout master + install + build + relink 扩展 + 冒烟
+```
+
+### 3.3 switch / rollback / confirm
+
+- switch：原子 `ln -sfn current -> 候选槽` + 验证 launcher + 重启 web（不变）。
+- rollback：current 指回 previousTarget（另一槽 = 旧 npm 版本，保留）。
+- confirm：生产 gate（HTTP 200 + manifest + launcher 链）不变。
+
+---
+
+## 四、配置（ab-config.json 扩展）
+
+```jsonc
+{
+  "upstream": "npm:@deepseek-ai/dsh",          // 不再用 git URL
+  "npm": {
+    "distTag": "next",                          // 跟随 next（rc 流）；正式版后改 latest
+    "registry": "https://registry.npmjs.org/",
+    "cacheDir": "~/.dsh/npm-cache"
+  },
+  "extensions": [
+    {
+      "name": "dsh-track",
+      "npm": "@fakechris/dsh-track",            // npm 形态包名（不写死，可配任意 scope）
+      "profile": "web",
+      "skills": ["skills/dsh-track"],
+      // 旧 relink/tsconfig/build 字段保留，仅 --source 源码模式用
+    }
+  ]
+}
+```
+
+---
+
+## 五、兼容与迁移
+
+- **旧源码槽保留**：slot-a 已是官方 master（0.1.0-rc.5）——`--source` 模式可直接用它，
+  不浪费。
+- **回滚链**：确认前旧槽（slot-b 私有快照 20260812 或 npm 旧版）保留。
+- **SKILL.md / 用户引导**：更新「何时用」触发词（官方发 npm 新版 → AB 轮换）。
+- **双语**：机制文档 + SKILL.md description 中英同步。
+
+---
+
+## 六、遗留问题
+
+1. npm 包闭包体积（`@deepseek-ai/dsh` 依赖 ~50 子包）——槽初始化比 git checkout 慢？
+   实测 `npx -p @deepseek-ai/dsh@0.1.0-rc.6 dsh --version` 首次 ~30s，可接受。
+2. `--source` 与 npm 模式的「当前版本」对比基准不同（git tip vs npm version）——
+   discover 需按当前槽的形态分别判断。
+3. 官方若恢复打 tag（`dsh-v<version>`），可加 `--tag` 源码模式精确对应 npm 版本。

--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -48,7 +48,7 @@ CMD="${1:-help}"
 shift || true
 
 FLAG_SLOT=""; FLAG_SNAPSHOT=""; FLAG_PORT=""; FLAG_SKIP_WEB=0; FLAG_KEEP=0; FLAG_FORCE=0; FLAG_YES=0; FLAG_JSON=0
-FLAG_FROM=""; FLAG_TO=""; FLAG_FULL=0
+FLAG_FROM=""; FLAG_TO=""; FLAG_FULL=0; FLAG_SOURCE=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --slot) FLAG_SLOT="${2:-}"; shift 2 ;;
@@ -56,6 +56,7 @@ while [ $# -gt 0 ]; do
     --port) FLAG_PORT="${2:-}"; shift 2 ;;
     --from) FLAG_FROM="${2:-}"; shift 2 ;;
     --to) FLAG_TO="${2:-}"; shift 2 ;;
+    --source) FLAG_SOURCE=1; shift ;;          # npm 形态之外的手动源码路径
     --skip-web) FLAG_SKIP_WEB=1; shift ;;
     --keep) FLAG_KEEP=1; shift ;;
     --force) FLAG_FORCE=1; shift ;;
@@ -108,6 +109,37 @@ cmd_status() {
 }
 
 cmd_discover() {
+  # --source: legacy git-snapshot discovery (private snapshot branches / master).
+  if [ "$FLAG_SOURCE" = "1" ]; then
+    cmd_discover_source
+    return 0
+  fi
+  # Default: npm dist-tag is the upstream truth (2026-08-14+).
+  local pkg tag cur_ver newest_ver newest_at
+  pkg=$(ab_npm_pkg); tag=$(ab_npm_dist_tag)
+  ab_log "checking npm dist-tag $pkg@$tag ..."
+  newest_ver=$(ab_npm_version "$tag")
+  [ -n "$newest_ver" ] || ab_die "cannot resolve npm dist-tag $tag for $pkg (registry unreachable?)"
+  newest_at=$(ab_npm_published_at "$newest_ver")
+  ab_log "upstream npm $pkg@$tag: $newest_ver (published ${newest_at:-?})"
+  cur_ver=$(ab_slot_version "$(ab_current_slot)")
+  ab_log "current slot version: ${cur_ver:-<none>}"
+  if [ -n "$cur_ver" ] && [ "$cur_ver" != "$newest_ver" ]; then
+    ab_log "next candidate: $newest_ver (current $cur_ver)"
+  elif [ -n "$cur_ver" ] && [ "$cur_ver" = "$newest_ver" ]; then
+    ab_log "no new npm version beyond the current slot (up to date)"
+  else
+    ab_log "next candidate: $newest_ver (current slot has no recorded version)"
+  fi
+  if [ "$FLAG_JSON" = "1" ]; then
+    printf '{"package":"%s","distTag":"%s","version":"%s","publishedAt":"%s","current":"%s"}\n' \
+      "$pkg" "$tag" "$newest_ver" "${newest_at:-}" "${cur_ver:-}"
+  fi
+}
+
+# cmd_discover_source — legacy git-based discovery (snapshots/* or master),
+# reachable via `ab.sh discover --source`; kept for manual source-slot rotation.
+cmd_discover_source() {
   [ -n "$AB_MAIN" ] || ab_die "no main clone resolved"
   local upstream; upstream=$(ab_config_get '.upstream // "origin"')
   ab_log "fetching upstream ($upstream)..."
@@ -280,7 +312,21 @@ cmd_init() {
 cmd_prepare() {
   ab_is_initialized || ab_die "not initialized — run: ab.sh init --yes"
   [ -n "$AB_MAIN" ] || ab_die "no main clone resolved"
-  local slot other cur snap cand_ref cand_branch dir
+  # --source: legacy source-checkout prepare (git master / snapshot branches).
+  if [ "$FLAG_SOURCE" = "1" ]; then
+    cmd_prepare_source
+    return $?
+  fi
+  # Default: npm-package slot (2026-08-14+). The slot is a DSH_HOME directory
+  # holding one npm version; extensions are npm packages in its profile.
+  cmd_prepare_npm
+}
+
+# cmd_prepare_npm — prepare a candidate slot from the npm dist-tag.
+# Slot layout: <slot-dir> is a DSH_HOME (profiles/web + node_modules); the
+# profile declares the official bundles plus extensions' npm packages.
+cmd_prepare_npm() {
+  local slot other cur dir
   slot="$FLAG_SLOT"
   cur=$(ab_current_slot)
   if [ -z "$slot" ]; then other=$(ab_other_slot); slot="$other"; fi
@@ -290,7 +336,103 @@ cmd_prepare() {
   if [ "$phase" = "switched" ] && [ "$confirmed" = "false" ] && [ "$FLAG_FORCE" != "1" ]; then
     ab_die "current version is not yet confirmed stable — slot '$slot' is the only rollback; run 'ab.sh confirm' after the user confirms, or pass --force"
   fi
-  git -C "$AB_MAIN" fetch origin 2>&1 | tail -1 || true
+
+  local pkg tag version published
+  pkg=$(ab_npm_pkg); tag=$(ab_npm_dist_tag)
+  version="${FLAG_SNAPSHOT:-$(ab_npm_version "$tag")}"
+  [ -n "$version" ] || ab_die "cannot resolve npm $pkg@$tag"
+  published=$(ab_npm_published_at "$version")
+  ab_log "preparing slot $slot <- npm $pkg@$version (published ${published:-?})"
+
+  # nothing to do if this version is already running or already prepared here
+  local cur_ver cand_phase cand_ver
+  cur_ver=$(ab_slot_version "$cur")
+  cand_phase=$(ab_state_get '.phase // "idle"')
+  cand_ver=$(ab_state_get '.candidateVersion // ""')
+  if [ "$version" = "$cur_ver" ]; then
+    ab_warn "npm $pkg@$version is the running version; nothing new to prepare"
+    return 0
+  fi
+  if [ "$cand_phase" = "prepared" ] && [ "$(ab_state_get '.candidate // ""')" = "$slot" ] && [ "$cand_ver" = "$version" ]; then
+    ab_warn "npm $pkg@$version already prepared in slot $slot — run 'ab.sh verify' instead"
+    return 0
+  fi
+
+  dir=$(ab_slot_dir "$slot")
+  ab_log "slot dir: $dir"
+  ab_lock "prepare-$$" || ab_die "another A/B operation holds the lock"
+  trap 'ab_unlock' EXIT
+
+  # --- (re)build the slot as an isolated DSH_HOME --------------------------
+  rm -rf "$dir"; mkdir -p "$dir/profiles/web"
+  if ! acc_npm_install "$dir" "$pkg" "$version"; then ab_warn "npm slot install failed"; ab_fail_prepare "$slot"; fi
+
+  # --- extensions: add their npm packages to the slot closure --------------
+  # Extensions' peer deps (@deepseek-ai/*) must resolve from the SAME closure
+  # as the official dsh packages (profiles/node_modules), so install them
+  # there, then declare each in profiles/web as a bundle row.
+  local exts n i ext extnpm extname
+  exts=$(ab_config_get '.extensions // [] | length')
+  i=0
+  while [ "$i" -lt "$exts" ]; do
+    ext=$(ab_config_get ".extensions[$i]")
+    extname=$(printf '%s' "$ext" | jq -r '.name // ""')
+    extnpm=$(printf '%s' "$ext" | jq -r '.npm // ""')
+    if [ -n "$extnpm" ]; then
+      ab_log "  closure add $extnpm -> $dir/profiles"
+      if ! (cd "$dir/profiles" && npm install --registry="$(ab_npm_registry)" "$extnpm" --no-audit --no-fund >/dev/null 2>&1); then
+        ab_warn "npm install $extnpm failed"; ab_fail_prepare "$slot"
+      fi
+      if [ -n "$extname" ]; then
+        ab_log "  profile bundle += $extname"
+        python3 - "$dir/profiles/web/package.json" "$extname" <<'PY'
+import json, sys
+p, name = sys.argv[1], sys.argv[2]
+d = json.load(open(p))
+d.setdefault("dsh", {}).setdefault("profile", {}).setdefault("bundles", [])
+if name not in d["dsh"]["profile"]["bundles"]:
+    d["dsh"]["profile"]["bundles"].append(name)
+json.dump(d, open(p, "w"), indent=2, ensure_ascii=False)
+open(p, "a").write("\n")
+PY
+      fi
+    else
+      ab_warn "extension $extname has no npm field — skipped (source mode: --source)"
+    fi
+    i=$((i + 1))
+  done
+
+  # --- slot launcher (current/bin/dsh -> npm CLI bin) -----------------------
+  ab_ensure_slot_launcher_npm "$dir"
+
+  # --- web smoke on a staging port ------------------------------------------
+  local wport whost wtimeout
+  wport=$(ab_config_get '.web.port // 3081'); whost=$(ab_config_get '.web.host // "127.0.0.1"'); wtimeout=$(ab_config_get '.web.startupTimeoutSec // 180')
+  if lsof -iTCP:"$wport" -sTCP:LISTEN >/dev/null 2>&1; then
+    ab_warn "port $wport busy — skipping web smoke (use --keep with a free port, or check the config)"
+  else
+    if ! acc_web_smoke "$dir" "$wport" "$whost" "$wtimeout" "$FLAG_KEEP" "$FLAG_YES"; then
+      ab_warn "web smoke FAILED"; ab_fail_prepare "$slot"
+    fi
+  fi
+
+  # --- record prepared state ------------------------------------------------
+  ab_state_set --arg at "$(ab_now)" --arg slot "$slot" --arg ver "$version" --arg pub "${published:-}" '
+    .phase = "prepared" | .candidate = $slot | .candidateVersion = $ver
+    | .candidateEvidence = { preparedAt: $at, slot: $slot, version: $ver, publishedAt: $pub, mode: "npm" }
+    | .slots[$slot].version = $ver
+    | .history += [{ at: $at, action: "prepare", slot: $slot, version: $ver, mode: "npm" }]'
+  ab_save_state
+  ab_ok "prepared slot $slot <- $pkg@$version (npm mode)"
+  ab_log "next: ab.sh verify (re-check) → ab.sh e2e (browser) → ab.sh switch --yes"
+}
+
+cmd_prepare_source() {
+  local slot other cur cand_branch dir
+  slot="$FLAG_SLOT"
+  cur=$(ab_current_slot)
+  if [ -z "$slot" ]; then other=$(ab_other_slot); slot="$other"; fi
+  [ "$slot" != "$cur" ] || ab_die "candidate slot '$slot' is the current slot — pick the other one"
   if [ -n "$FLAG_SNAPSHOT" ]; then
     cand_branch="$FLAG_SNAPSHOT"
   else
@@ -412,8 +554,8 @@ ab_fail_prepare() {
     ext_restore_all "$_e2"
   done < <(ab_config_items '.extensions // [] | .[]')
   ab_state_set --arg slot "$slot" --arg at "$(ab_now)" '
-    .slots[$slot].snapshot = null | .slots[$slot].tip = null
-    | .phase = "idle" | .candidate = null | .candidateSnapshot = null
+    .slots[$slot].snapshot = null | .slots[$slot].tip = null | .slots[$slot].version = null
+    | .phase = "idle" | .candidate = null | .candidateSnapshot = null | .candidateVersion = null
     | .history += [{ at: $at, action: "prepare-failed", slot: $slot }]'
   ab_save_state
   ab_unlock

--- a/skills/dsh-snapshot-ab/scripts/lib/acceptance.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/acceptance.sh
@@ -69,6 +69,37 @@ acc_install() {
   ( cd "$dir" && pnpm install --frozen-lockfile 2>&1 | tail -5 )
 }
 
+# acc_npm_install <slot-dir> <pkg> <version> — install an npm-distribution slot.
+# The slot is a DSH_HOME: profiles/web declares the official bundles; the dsh
+# CLI lives in profiles/node_modules (pnpm closure) so bin.js resolves from
+# there. Idempotent per slot (rm -rf happens in cmd_prepare_npm).
+acc_npm_install() {
+  local dir="$1" pkg="$2" version="$3" reg
+  reg=$(ab_npm_registry)
+  ab_log "npm slot install: $pkg@$version (registry $reg)"
+  mkdir -p "$dir/profiles/web"
+  cat > "$dir/profiles/web/package.json" <<'EOF'
+{
+  "name": "dsh-profile-web",
+  "private": true,
+  "dsh": { "profile": { "bundles": ["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app"] } },
+  "dependencies": {}
+}
+EOF
+  mkdir -p "$dir/profiles/node_modules"
+  cat > "$dir/profiles/package.json" <<'EOF'
+{
+  "name": "dsh-slot-closure",
+  "private": true,
+  "dependencies": {}
+}
+EOF
+  ( cd "$dir/profiles" && npm install "$pkg@$version" --registry="$reg" --no-audit --no-fund 2>&1 | tail -4 )
+  [ -x "$dir/profiles/node_modules/.bin/dsh" ] || [ -f "$dir/profiles/node_modules/$pkg/bin.js" ] \
+    || { ab_err "npm slot install: dsh CLI not found after install"; return 1; }
+  ab_log "  npm slot closure installed: $(ls "$dir/profiles/node_modules/@deepseek-ai/" 2>/dev/null | wc -l | tr -d ' ') @deepseek-ai packages"
+}
+
 # acc_build <candidate-dir> <skip-web>
 acc_build() {
   local dir="$1" skip_web="${2:-0}"

--- a/skills/dsh-snapshot-ab/scripts/lib/common.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/common.sh
@@ -141,6 +141,32 @@ ab_other_slot() {
 
 ab_is_initialized() { [ "$(ab_state_get '.current // ""')" != "" ]; }
 
+# ---- npm helpers (npm-distribution mode, 2026-08-14+) ----------------------
+
+# The npm package that is the upstream truth (ab-config npm.package).
+ab_npm_pkg() { ab_config_get '.npm.package // "@deepseek-ai/dsh"'; }
+# Which dist-tag to follow (ab-config npm.distTag; default next for rc stream).
+ab_npm_dist_tag() { ab_config_get '.npm.distTag // "next"'; }
+ab_npm_registry() { ab_config_get '.npm.registry // "https://registry.npmjs.org/"'; }
+
+# ab_npm_version <dist-tag> — the version currently published under a dist-tag.
+ab_npm_version() {
+  local tag pkg reg
+  tag="${1:-$(ab_npm_dist_tag)}"
+  pkg=$(ab_npm_pkg); reg=$(ab_npm_registry)
+  npm view "$pkg" dist-tags."$tag" --registry="$reg" 2>/dev/null || true
+}
+
+# ab_npm_published_at <version> — ISO timestamp when a version was published.
+ab_npm_published_at() {
+  local ver pkg reg
+  ver="$1"; pkg=$(ab_npm_pkg); reg=$(ab_npm_registry)
+  npm view "$pkg" time --registry="$reg" --json 2>/dev/null | jq -r --arg v "$ver" '.[$v] // ""' 2>/dev/null || true
+}
+
+# ab_slot_version <slot> — npm version the slot was prepared with (state).
+ab_slot_version() { local s="$1"; [ -n "$s" ] || { printf ''; return; }; ab_state_get ".slots.$s.version // \"\""; }
+
 # ab_boot_cmd <dir> — command line that boots this slot's dsh CLI in the SAME
 # way production runs it. Order matters:
 #   1. bin/dsh        — the launcher chain (~/.local/bin/dsh -> current/bin/dsh)
@@ -208,6 +234,31 @@ EOF
     ln -sfn "$HOME/.dsh/skills/dsh-web-doctor/scripts/doctor.sh" "$dir/bin/dsh-doctor"
     ab_log "  slot doctor -> $dir/bin/dsh-doctor"
   fi
+}
+
+# ab_ensure_slot_launcher_npm <slot-dir> — npm-distribution slot launcher.
+# An npm slot is a DSH_HOME whose dsh CLI lives in the profile/node_modules
+# closure (@deepseek-ai/dsh). Prefer the .bin/dsh symlink npm created (it
+# points at the package's real bin entry); fall back to resolving it directly.
+ab_ensure_slot_launcher_npm() {
+  local dir="$1" pkg binjs
+  [ -x "$dir/bin/dsh" ] && return 0
+  pkg=$(ab_npm_pkg)
+  binjs="$dir/profiles/node_modules/.bin/dsh"
+  if [ ! -e "$binjs" ]; then
+    binjs=$(node -e "try{console.log(require.resolve('$pkg/bin.js',{paths:['$dir/profiles/node_modules']}))}catch(e){}" 2>/dev/null || true)
+  fi
+  [ -n "$binjs" ] && [ -e "$binjs" ] || { ab_warn "  npm launcher: cannot locate $pkg CLI in slot $dir"; return 1; }
+  mkdir -p "$dir/bin"
+  cat > "$dir/bin/dsh" <<EOF
+#!/bin/sh
+# slot launcher (npm distribution): boots the npm-installed dsh CLI.
+# Managed by ab.sh (ab_ensure_slot_launcher_npm); do not edit.
+set -eu
+exec node "$binjs" "\$@"
+EOF
+  chmod +x "$dir/bin/dsh"
+  ab_log "  slot launcher -> $dir/bin/dsh (npm $pkg via $binjs)"
 }
 
 # ab_verify_relinks — self-heal the extensions' node_modules relinks against


### PR DESCRIPTION
## 为什么
官方 DSH 2026-08-13 从私有快照转为公开仓库 + npm 发布。**npm registry 是唯一发布真相**（master 可能落后 npm、无 git tag——实测 npm 0.1.0-rc.6 领先 master 的 rc.5）。AB 轮换必须跟随 npm dist-tag，不能跟随 git。

## 改了什么
- **discover**：默认查 `@deepseek-ai/dsh` dist-tag（next/latest）；`--source` 保留旧 git-snapshot 发现
- **prepare**：默认把槽建成独立 DSH_HOME——npm 包装进 profiles/node_modules 闭包，扩展（`extensions[].npm`）同闭包安装 + profile bundles 声明，生成 bin/dsh launcher（npm CLI），staging 冒烟；`--source` 保留源码路径（git master + 构建 + relink）
- **helpers**：ab_npm_version / ab_npm_published_at / ab_slot_version / ab_ensure_slot_launcher_npm / acc_npm_install
- **config**：ab-config.example.json 加 npm{package,distTag,registry,cacheDir} + extensions[].npm；upstream → 'npm:@deepseek-ai/dsh'
- **SKILL.md + mechanism-design-npm.md**：npm 模式文档（双语）

## 验证（隔离环境，未动生产）
- discover：解析 dist-tag → 0.1.0-rc.6，publishedAt 正确
- prepare：`@deepseek-ai/dsh@0.1.0-rc.3` 闭包（195 个 @deepseek-ai 包）+ `@fakechris/dsh-track`，扩展 peer 从槽闭包解析，冒烟 HTTP 200
- switch/rollback/confirm 未改，兼容（bin/dsh launcher 链保留）
- 扩展不写死 fakechris：extensions[].npm 可配任意 scope