### PR TITLE
docs(readme): reflect v0.3.1/v0.3.2 — LISTEN-only guard check, layout-aware relink, npm-published bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ plugins/*/node_modules/
 
 # nested git worktrees (inside the workspace sandbox root)
 .worktrees/
+
+# bundle 插件零依赖，pnpm install 生成的锁文件无意义
+plugins/dsh-restart-recover/pnpm-lock.yaml

--- a/README.en.md
+++ b/README.en.md
@@ -225,6 +225,8 @@ bash scripts/install.sh
 
 # Optional: self-healing daemon (launchd/systemd, relaunches web ~10s after death)
 bash skills/dsh-web-guard/scripts/install.sh
+#   v0.3.1+: liveness check only counts LISTEN sockets (-sTCP:LISTEN) — a
+#   browser page holding connections no longer blocks the restart
 
 # Configure (auto-read on first run; see skills/dsh-snapshot-ab/references/ab-config.example.json)
 #    Usually you only confirm extensions (extension repo paths) and the web port in ab-config.json
@@ -234,14 +236,15 @@ vi ~/.dsh/source/ab-config.json
 $AB status
 ```
 
-> **Versioning & release**: this repository IS the distribution unit (GitHub is
-> the distribution — **no npm publish**, official stance in
+> **Versioning & release**: the repository IS the distribution unit (GitHub) —
+> skills (directory mechanism) are not on npm; the bundle plugin
+> `@fakechris/dsh-restart-recover` **is published to npm** (official stance in
 > [`docs/RELEASE.md`](docs/RELEASE.md)). Version = root `VERSION` file + git tag
 > `vX.Y.Z` + [`CHANGELOG.md`](CHANGELOG.md) (SemVer).
 > **Updates need no manual packaging**: `bash scripts/update.sh` does
 > `git pull → rebuild plugin lib → reinstall skills/bundle` in one step
-> (the bundle plugin ships a `prepare` script, so a git fetch of sources
-> rebuilds itself on install).
+> (v0.3.2+: auto-resolves the toolchain slot and self-heals the plugin's build
+> links, so rotating to an npm-profile-layout slot no longer breaks the build).
 
 ```sh
 # Every update afterwards

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ bash scripts/install.sh
 
 # 可选：自愈守护（launchd/systemd，web 死后 10s 自动拉起）
 bash skills/dsh-web-guard/scripts/install.sh
+#   v0.3.1 起判活只认 LISTEN 态 socket（-sTCP:LISTEN）——浏览器页面挂着的连接
+#   不会再把端口误判为"被占用"，web 死后守护必定拉起
 
 # 配置（首次会自动读，示例见 skills/dsh-snapshot-ab/references/ab-config.example.json）
 # 通常只需确认 ab-config.json 里的 extensions（扩展仓库路径）与 web 端口
@@ -218,11 +220,13 @@ vi ~/.dsh/source/ab-config.json
 $AB status
 ```
 
-> **版本与发布**：本仓库是**发布单元**（GitHub 即分发，**不进 npm**，官方立场见
+> **版本与发布**：仓库是发布单元（GitHub 即分发）——skills（目录机制）不进 npm；
+> bundle 插件 `@fakechris/dsh-restart-recover` 已发 **npm**（官方立场见
 > [`docs/RELEASE.md`](docs/RELEASE.md)）。版本 = 根目录 `VERSION` + git tag `vX.Y.Z` +
 > [`CHANGELOG.md`](CHANGELOG.md)（SemVer）。
 > **更新不需要手工打包**：`bash scripts/update.sh` 一条命令完成
-> `git pull → 重建插件 lib → 重装 skills/bundle`（bundle 插件自带 `prepare` 脚本，git 拉源码后自动构建）。
+> `git pull → 重建插件 lib → 重装 skills/bundle`（v0.3.2 起自动解析工具链槽位 +
+> 自愈插件构建软链，轮换到 npm profile 布局槽位不再断链）。
 
 ```sh
 # 之后每次更新


### PR DESCRIPTION
README 双语（L6）反映最新修改：
- 自愈守护说明：判活只认 LISTEN 态 socket（v0.3.1 #59）——浏览器连接不再挡住重启
- update.sh 说明：自动解析工具链槽 + 自愈构建软链（v0.3.2 #61）——npm profile 布局槽位不再断链
- 版本与发布说明修正：skills 目录机制不进 npm；bundle 插件 @fakechris/dsh-restart-recover 已在 npm
- .gitignore：零依赖插件 pnpm install 的锁文件副产物