### PR TITLE
fix(install): use published restart recovery bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Each entry links its squash-merged PR.
 
 ## [Unreleased]
 
+- `fix(install)`: production profiles install the published
+  `@fakechris/dsh-restart-recover` artifact instead of a local `link:`. This
+  keeps `lib/index.js` owned by the installed tarball, so cleaning ignored
+  checkout outputs cannot put `dsh web` into a permanent restart loop.
+
 ## [0.3.2] — 2026-08-14
 
 **扩展构建链路修复 —— relink 布局兼容。** 轮换到正式版（npm profile 布局）槽位后，

--- a/README.en.md
+++ b/README.en.md
@@ -229,7 +229,7 @@ bash skills/dsh-web-guard/scripts/install.sh
 #   browser page holding connections no longer blocks the restart
 
 # Configure (auto-read on first run; see skills/dsh-snapshot-ab/references/ab-config.example.json)
-#    Usually you only confirm extensions (extension repo paths) and the web port in ab-config.json
+#    Usually you only confirm extensions (including dsh-restart-recover) and the web port
 vi ~/.dsh/source/ab-config.json
 
 # Verify
@@ -241,10 +241,10 @@ $AB status
 > `@fakechris/dsh-restart-recover` **is published to npm** (official stance in
 > [`docs/RELEASE.md`](docs/RELEASE.md)). Version = root `VERSION` file + git tag
 > `vX.Y.Z` + [`CHANGELOG.md`](CHANGELOG.md) (SemVer).
-> **Updates need no manual packaging**: `bash scripts/update.sh` does
-> `git pull → rebuild plugin lib → reinstall skills/bundle` in one step
-> (v0.3.2+: auto-resolves the toolchain slot and self-heals the plugin's build
-> links, so rotating to an npm-profile-layout slot no longer breaks the build).
+> **Updates do not build the plugin locally**: `bash scripts/update.sh` does
+> `git pull → reinstall skills → reinstall the bundle from npm` in one step.
+> The production profile uses the published `@fakechris/dsh-restart-recover`
+> artifact, never a checkout whose ignored `lib/` can be cleaned away.
 
 ```sh
 # Every update afterwards
@@ -255,6 +255,8 @@ cd dsh-harness-ops && bash scripts/update.sh
 repo/relink/build commands), `web.port` (staging smoke port, default 3081),
 `web.productionPort` (default 3080), `web.smokeClientIds` (client-manifest assertion),
 **`acceptance`** (acceptance switch, below).
+The example also lists `dsh-restart-recover` as an npm extension, so every new
+candidate slot installs the published artifact instead of repairing only the current slot.
 
 ### Acceptance mode switch (`acceptance`)
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ bash skills/dsh-web-guard/scripts/install.sh
 #   不会再把端口误判为"被占用"，web 死后守护必定拉起
 
 # 配置（首次会自动读，示例见 skills/dsh-snapshot-ab/references/ab-config.example.json）
-# 通常只需确认 ab-config.json 里的 extensions（扩展仓库路径）与 web 端口
+# 通常只需确认 ab-config.json 里的 extensions（包括 dsh-restart-recover）与 web 端口
 vi ~/.dsh/source/ab-config.json
 
 # 验证
@@ -224,9 +224,9 @@ $AB status
 > bundle 插件 `@fakechris/dsh-restart-recover` 已发 **npm**（官方立场见
 > [`docs/RELEASE.md`](docs/RELEASE.md)）。版本 = 根目录 `VERSION` + git tag `vX.Y.Z` +
 > [`CHANGELOG.md`](CHANGELOG.md)（SemVer）。
-> **更新不需要手工打包**：`bash scripts/update.sh` 一条命令完成
-> `git pull → 重建插件 lib → 重装 skills/bundle`（v0.3.2 起自动解析工具链槽位 +
-> 自愈插件构建软链，轮换到 npm profile 布局槽位不再断链）。
+> **更新不需要本地构建插件**：`bash scripts/update.sh` 一条命令完成
+> `git pull → 重装 skills → 从 npm 重装 bundle`。生产 profile 固定使用已发布的
+> `@fakechris/dsh-restart-recover`，不会再链接仓库中可能被清理的 `lib/`。
 
 ```sh
 # 之后每次更新
@@ -236,6 +236,7 @@ cd dsh-harness-ops && bash scripts/update.sh
 `ab-config.json` 关键字段：`upstream`（官方仓库）、`extensions[]`（扩展列表：repo/relink/构建命令）、
 `web.port`（staging 冒烟端口，默认 3081）、`web.productionPort`（默认 3080）、
 `web.smokeClientIds`（client-manifest 断言）、**`acceptance`**（验收开关，见下）。
+示例把 `dsh-restart-recover` 也列为 npm 扩展，保证新候选槽安装正式包，而不是只修当前槽。
 
 ### 验收模式开关（`acceptance`）
 

--- a/docs/RELEASE.en.md
+++ b/docs/RELEASE.en.md
@@ -106,14 +106,14 @@ component uses its own mechanism:
 | Component | Type | Distribution/install | Update action |
 |---|---|---|---|
 | `skills/dsh-snapshot-ab`, `dsh-web-guard`, `dsh-session-recovery` | skill | copy into `~/.dsh/skills/` (official scan dir) | re-copy via `install.sh` |
-| `plugins/dsh-restart-recover` | bundle | `dsh plugin --profile web add .` (pnpm link + bundle register) | `update.sh` rebuilds lib + re-adds |
+| `plugins/dsh-restart-recover` | bundle | `dsh plugin --profile web add @fakechris/dsh-restart-recover@<version>` (published npm artifact) | `update.sh` reinstalls from npm |
 
-The bundle ships a `prepare` script (`node scripts/dsh-env.mjs tsc -p tsconfig.json`),
-so **a git fetch of sources rebuilds lib/ automatically** — exactly the official
-git-install requirement. Skills need no build.
+The npm tarball includes `lib/`. Production profiles do not use a local `link:`,
+so cleaning ignored checkout artifacts cannot prevent `dsh web` from starting.
+The `prepare` script remains for plugin development and pre-publish builds. Skills need no build.
 
 **`bash scripts/update.sh` does the whole update in one command**:
-`git pull --ff-only → rebuild plugin lib → re-run install.sh`.
+`git pull --ff-only → re-run install.sh → reinstall the bundle from npm`.
 
 ### 2.2 Versioning
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -88,12 +88,12 @@ npm registry 现状：`@deepseek-ai/*` scope 在 npm 上**无任何包**（`npm 
 | 组件 | 类型 | 分发/安装机制 | 更新动作 |
 |---|---|---|---|
 | `skills/dsh-snapshot-ab`、`dsh-web-guard`、`dsh-session-recovery` | skill | 目录复制到 `~/.dsh/skills/`（官方扫描目录） | `install.sh` 重拷 |
-| `plugins/dsh-restart-recover` | bundle 插件 | `dsh plugin --profile web add .`（pnpm link + bundle 注册） | `update.sh` 重建 lib + 重装 |
+| `plugins/dsh-restart-recover` | bundle 插件 | `dsh plugin --profile web add @fakechris/dsh-restart-recover@<version>`（npm 发布物） | `update.sh` 从 npm 重装 |
 
-bundle 插件自带 `prepare` 脚本（`node scripts/dsh-env.mjs tsc -p tsconfig.json`），
-**git 拉源码后自动构建 lib/** —— 这正是官方 git 直装的要求。skills 无需构建。
+bundle 插件的 npm tarball 自带 `lib/`。生产 profile 不使用本地 `link:`，避免仓库清理
+忽略产物后导致 `dsh web` 无法启动。`prepare` 脚本保留给插件开发和发布前构建；skills 无需构建。
 
-**`bash scripts/update.sh` 一条命令完成全部更新**：`git pull --ff-only → 重建插件 lib → 重跑 install.sh`。
+**`bash scripts/update.sh` 一条命令完成全部更新**：`git pull --ff-only → 重跑 install.sh → 从 npm 重装 bundle`。
 
 ### 2.2 版本号管理
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,11 +2,11 @@
 # dsh-harness-ops installer — one command to install (or re-install) this
 # toolbox on a machine:
 #   1. copies the four skills into ~/.dsh/skills (the default scan dir),
-#   2. installs the dsh-restart-recover bundle into the `web` profile
-#      (via `dsh plugin add`, the official pnpm-backed mechanism),
+#   2. installs the published dsh-restart-recover bundle into the `web`
+#      profile (via `dsh plugin add`, the official pnpm-backed mechanism),
 #   3. prints a hint for the optional web-guard daemon.
-# Idempotent — safe to re-run after every update. Distribution unit is this
-# git checkout; there is no npm publish (see docs/RELEASE.md).
+# Idempotent — safe to re-run after every update. Skills come from this git
+# checkout; the bundle is a separately published npm artifact.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -29,24 +29,28 @@ done
 [ "$installed" = "1" ] || { echo "error: no skills found in $ROOT/skills"; exit 1; }
 
 # --- 2) bundle plugin into the web profile -----------------------------------
-PLUGIN="$ROOT/plugins/dsh-restart-recover"
-if [ -d "$PLUGIN" ]; then
+PLUGIN_PACKAGE="@fakechris/dsh-restart-recover"
+PLUGIN_MANIFEST="$ROOT/plugins/dsh-restart-recover/package.json"
+if [ -f "$PLUGIN_MANIFEST" ]; then
   if ! command -v dsh >/dev/null 2>&1; then
     echo "  warn: 'dsh' not on PATH — skipping profile bundle install (skills are installed)"
   else
-    echo "  bundle: installing $PLUGIN into the web profile (pnpm-backed)..."
-    # first install/build the plugin's own deps, then let `dsh plugin add`
-    # (which forwards to pnpm in the profile dir) register the bundle layer.
-    ( cd "$PLUGIN" && pnpm install --frozen-lockfile >/dev/null 2>&1 || pnpm install >/dev/null 2>&1 )
-    if ( cd "$PLUGIN" && dsh plugin --profile web add . ) >/tmp/dsh-harness-ops-plugin.log 2>&1; then
-      echo "  bundle -> web profile: @fakechris/dsh-restart-recover"
+    PLUGIN_VERSION=$(sed -n 's/^[[:space:]]*"version": "\([^"]*\)".*/\1/p' "$PLUGIN_MANIFEST" | head -1)
+    [ -n "$PLUGIN_VERSION" ] || { echo "error: cannot read bundle version from $PLUGIN_MANIFEST"; exit 1; }
+    PLUGIN_SPEC="$PLUGIN_PACKAGE@$PLUGIN_VERSION"
+    echo "  bundle: installing $PLUGIN_SPEC into the web profile (registry artifact)..."
+    # A local path makes pnpm persist a link: dependency. Its ignored lib/
+    # output can disappear after a clean and then prevent dsh web from booting.
+    # The published tarball owns lib/, so production profiles use it directly.
+    if dsh plugin --profile web add "$PLUGIN_SPEC" >/tmp/dsh-harness-ops-plugin.log 2>&1; then
+      echo "  bundle -> web profile: $PLUGIN_SPEC"
     else
-      echo "  warn: 'dsh plugin --profile web add .' failed (see /tmp/dsh-harness-ops-plugin.log)"
-      echo "        if the bundle is already linked, this is fine; check with: dsh plugin --profile web ls"
+      echo "  warn: 'dsh plugin --profile web add $PLUGIN_SPEC' failed (see /tmp/dsh-harness-ops-plugin.log)"
+      echo "        check the registry and profile with: dsh plugin --profile web ls"
     fi
   fi
 else
-  echo "  warn: plugin dir missing: $PLUGIN"
+  echo "  warn: plugin manifest missing: $PLUGIN_MANIFEST"
 fi
 
 # --- 3) one-command doctor entry on PATH -------------------------------------

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,11 +2,9 @@
 # dsh-harness-ops updater — one command to update this toolbox from git and
 # re-apply it locally:
 #   1. git fetch + fast-forward main,
-#   2. rebuild the bundle plugin's lib (a git pull fetches SOURCES, not built
-#      artifacts — the plugin's `prepare` script compiles lib/ self-contained),
-#   3. re-run the installer (skills re-copy, bundle re-add — idempotent).
-# No manual "packaging" step is needed: git is the distribution unit and the
-# plugin builds itself on install (official pattern, docs/RELEASE.md).
+#   2. re-run the installer (skills re-copy, published bundle re-add —
+#      idempotent).
+# The web profile consumes the published bundle, never a local checkout link.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -17,53 +15,6 @@ git -C "$ROOT" fetch origin 2>&1 | tail -1 || true
 git -C "$ROOT" pull --ff-only origin main
 
 NEW="$(cat "$ROOT/VERSION" 2>/dev/null || echo unknown)"
-
-# ---- toolchain slot resolution (2026-08-14) ----
-# The npm/profile-layout slots (formal release) carry no dev toolchain
-# (no node_modules/.bin/tsc — the pnpm closure is runtime-only). Resolve a
-# source-layout slot that has one; the build runs against that slot's types.
-resolve_toolchain() {
-  local cur="$HOME/.dsh/source/current"
-  [ -x "$cur/node_modules/.bin/tsc" ] && { printf '%s' "$cur"; return 0; }
-  local d
-  for d in "$HOME"/.dsh/source/slot-*; do
-    [ -x "$d/node_modules/.bin/tsc" ] && { printf '%s' "$d"; return 0; }
-  done
-  printf '%s' "$cur"
-}
-DSH_SOURCE="${DSH_SOURCE:-$(resolve_toolchain)}"
-export DSH_SOURCE
-echo "  toolchain: $DSH_SOURCE"
-
-# rebuild the bundle plugin's lib from the freshly fetched sources
-PLUGIN="$ROOT/plugins/dsh-restart-recover"
-if [ -d "$PLUGIN" ]; then
-  # The bundle plugin declares no dependencies (profile injects them at
-  # runtime), so tsc resolves @deepseek-ai/* types through node_modules
-  # links — self-heal them against the toolchain slot, layout-aware:
-  # legacy monorepo path first, npm profile closure fallback.
-  mkdir -p "$PLUGIN/node_modules/@deepseek-ai"
-  while IFS='|' read -r pkg rel; do
-    [ -n "$pkg" ] || continue
-    link="@deepseek-ai/$pkg"
-    target="$DSH_SOURCE/$rel"
-    { [ -e "$target" ] || [ -L "$target" ]; } || target="$DSH_SOURCE/profiles/node_modules/$link"
-    { [ -e "$target" ] || [ -L "$target" ]; } || { echo "  [relink] WARN: $link unresolvable under $DSH_SOURCE"; continue; }
-    ln -sfn "$target" "$PLUGIN/node_modules/$link"
-    echo "  [relink] $link -> $target"
-  done <<'EOF'
-cordis|vendor/cordis
-dsh-agent|packages/core/agent
-dsh-session|packages/core/session
-EOF
-  ln -sfn "$DSH_SOURCE/vendor/cordis" "$PLUGIN/node_modules/cordis" 2>/dev/null \
-    || ln -sfn "$DSH_SOURCE/profiles/node_modules/@deepseek-ai/cordis" "$PLUGIN/node_modules/cordis" 2>/dev/null \
-    || true
-  echo "  rebuilding $PLUGIN/lib ..."
-  ( cd "$PLUGIN" && pnpm install --frozen-lockfile >/dev/null 2>&1 || pnpm install >/dev/null 2>&1 )
-  ( cd "$PLUGIN" && node scripts/dsh-env.mjs tsc -p tsconfig.json )
-  echo "  plugin lib rebuilt"
-fi
 
 # re-sync skills + profile bundle (idempotent)
 bash "$ROOT/scripts/install.sh"

--- a/skills/dsh-snapshot-ab/references/ab-config.example.json
+++ b/skills/dsh-snapshot-ab/references/ab-config.example.json
@@ -32,6 +32,24 @@
       "typecheck": "pnpm run typecheck",
       "build": "pnpm run build",
       "test": "pnpm test"
+    },
+    {
+      "name": "dsh-restart-recover",
+      "npm": "@fakechris/dsh-restart-recover",
+      "repo": "/Users/chris/source/dsh-skill-snapshot-ab/plugins/dsh-restart-recover",
+      "profile": "web",
+      "skills": [],
+      "relink": {
+        "node_modules/@deepseek-ai/cordis": "vendor/cordis",
+        "node_modules/@deepseek-ai/dsh-agent": "packages/core/agent",
+        "node_modules/@deepseek-ai/dsh-session": "packages/core/session",
+        "node_modules/vitest": "node_modules/vitest"
+      },
+      "tsconfig": "tsconfig.json",
+      "tsconfigOut": "tsconfig.ab.json",
+      "typecheck": "node scripts/dsh-env.mjs tsc -p tsconfig.ab.json --noEmit",
+      "build": "node scripts/dsh-env.mjs tsc -p tsconfig.ab.json",
+      "test": "npm test"
     }
   ],
   "web": {

--- a/skills/dsh-web-guard/SKILL.md
+++ b/skills/dsh-web-guard/SKILL.md
@@ -93,18 +93,16 @@ tail /tmp/dsh-web-guard.log                     # 应见 "port free — starting
 - 检测会话最后 turn 是 `interrupted` → 自动注入续接消息（含"结果未知的工具调用先核查、只读/幂等才重试"纪律）
 - agent 带着 `TOOL_OUTCOME_UNKNOWN` 上下文自动继续 —— **用户零输入**
 
-安装（官方 bundle 通道，`dsh.bundle.patch` 格式）：
+生产安装（官方 bundle 通道，`dsh.bundle.patch` 格式）：
 
 ```sh
-# 官方安装：bundle 走 dsh plugin（产物经 prepare 构建，DSH_SOURCE 指向当前槽）
-cd plugins/dsh-restart-recover
-DSH_SOURCE=/Users/chris/.dsh/source/current npm run prepare   # 生成 lib/
-dsh plugin --profile web add .                                 # 在包目录内 add .（官方 bundle 安装）
+# 使用 npm 发布物；tarball 自带 lib/，不会依赖本地 checkout 的忽略文件
+dsh plugin --profile web add @fakechris/dsh-restart-recover@0.2.1
 ```
 
-> 官方规范要点（对照 make-dsh-plugin）：bundle 插件的 `dependencies` **声明为空是设计**——
-> `@deepseek-ai/*` 官方包由 profile 的 pnpm 闭包注入（repository 插件才声明，两类相反）；
-> 产物不入库靠 `prepare` 脚本构建（git 源安装时 pnpm 自动跑）。
+> 不要在生产 profile 中运行 `dsh plugin --profile web add .`。本地路径会被 pnpm
+> 持久化为 `link:`；仓库的 `lib/` 是忽略产物，一旦被清理，下次启动就会因缺少
+> `lib/index.js` 失败。本地路径安装只用于插件开发，且必须先执行 `npm run prepare`。
 
 配置（`config.resumeAutoContinue`，均可省略）：
 - `enabled`（默认 true）

--- a/tests/install-registry-plugin.sh
+++ b/tests/install-registry-plugin.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Verify the installer registers the published restart-recover artifact, not a
+# local checkout link whose ignored lib/ directory can disappear.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/dsh-harness-ops-install.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/bin" "$TMP/home" "$TMP/skills"
+cat > "$TMP/bin/dsh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$DSH_INSTALL_TEST_ARGS"
+EOF
+cat > "$TMP/bin/pnpm" <<'EOF'
+#!/usr/bin/env bash
+echo "pnpm must not run during registry bundle installation" >&2
+exit 99
+EOF
+chmod +x "$TMP/bin/dsh" "$TMP/bin/pnpm"
+
+export HOME="$TMP/home"
+export DSH_SKILLS_DIR="$TMP/skills"
+export DSH_INSTALL_TEST_ARGS="$TMP/dsh-args"
+export PATH="$TMP/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+bash "$ROOT/scripts/install.sh" > "$TMP/install.log"
+
+VERSION=$(sed -n 's/^[[:space:]]*"version": "\([^"]*\)".*/\1/p' \
+  "$ROOT/plugins/dsh-restart-recover/package.json" | head -1)
+EXPECTED="plugin --profile web add @fakechris/dsh-restart-recover@$VERSION"
+ACTUAL=$(cat "$DSH_INSTALL_TEST_ARGS")
+[ "$ACTUAL" = "$EXPECTED" ] || {
+  echo "expected: $EXPECTED" >&2
+  echo "actual:   $ACTUAL" >&2
+  exit 1
+}
+
+grep -F "bundle -> web profile: @fakechris/dsh-restart-recover@$VERSION" "$TMP/install.log" >/dev/null
+echo "install-registry-plugin: pass"


### PR DESCRIPTION
## Summary

- install `@fakechris/dsh-restart-recover` from its versioned npm artifact instead of a local `link:`
- remove the obsolete local rebuild path from `update.sh`
- include restart recovery in the A/B configuration example and update bilingual operational docs
- add a regression test proving the installer does not invoke local `pnpm`

## Root cause

The production web profile linked the checkout directly. Because `plugins/dsh-restart-recover/lib/` is ignored, a cleanup removed `lib/index.js`; every guarded `dsh web` restart then failed during plugin-tree loading.

## Checks

- `bash tests/install-registry-plugin.sh`
- `bash -n scripts/install.sh scripts/update.sh tests/install-registry-plugin.sh`
- `jq -e` against the restart-recover extension in `ab-config.example.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Production installations now use the published restart-recovery package, improving reliability and preventing restart loops caused by missing local build files.
  * Updates now fetch the latest repository changes, reinstall skills, and install the published plugin without rebuilding locally.
  * Configuration examples and installation guidance now clearly document the restart-recovery extension and web port.

* **Tests**
  * Added coverage verifying registry-based plugin installation and version selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->