### PR TITLE
fix(ab): prepare must re-run when an extension's npm latest moved

### DIFF
--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -345,17 +345,27 @@ cmd_prepare_npm() {
   ab_log "preparing slot $slot <- npm $pkg@$version (published ${published:-?})"
 
   # nothing to do if this version is already running or already prepared here
-  local cur_ver cand_phase cand_ver
+  # AND every configured extension is at its npm latest in the current slot.
+  # Extensions resolve from their own dist-tag: a new dsh-track release can
+  # change behaviour while the dsh package version stays put (2026-08-21:
+  # dsh-track 0.6.0 shipped the session-graph feature that the running 0.5.0
+  # lacked; the old early-return skipped the reprepare entirely and the
+  # candidate never picked up the new extension).
+  local cur_ver cand_phase cand_ver ext_updated
   cur_ver=$(ab_slot_version "$cur")
   cand_phase=$(ab_state_get '.phase // "idle"')
   cand_ver=$(ab_state_get '.candidateVersion // ""')
-  if [ "$version" = "$cur_ver" ]; then
-    ab_warn "npm $pkg@$version is the running version; nothing new to prepare"
+  ext_updated=$(ab_any_ext_outdated "$cur")
+  if [ "$version" = "$cur_ver" ] && [ "$ext_updated" != "1" ]; then
+    ab_warn "npm $pkg@$version is the running version and extensions are current; nothing new to prepare"
     return 0
   fi
-  if [ "$cand_phase" = "prepared" ] && [ "$(ab_state_get '.candidate // ""')" = "$slot" ] && [ "$cand_ver" = "$version" ]; then
+  if [ "$cand_phase" = "prepared" ] && [ "$(ab_state_get '.candidate // ""')" = "$slot" ] && [ "$cand_ver" = "$version" ] && [ "$ext_updated" != "1" ]; then
     ab_warn "npm $pkg@$version already prepared in slot $slot — run 'ab.sh verify' instead"
     return 0
+  fi
+  if [ "$ext_updated" = "1" ]; then
+    ab_log "extension update detected (current slot has an outdated extension) — re-preparing slot $slot with the same dsh version"
   fi
 
   dir=$(ab_slot_dir "$slot")

--- a/skills/dsh-snapshot-ab/scripts/lib/common.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/common.sh
@@ -164,6 +164,32 @@ ab_npm_version() {
   npm view "$pkg" dist-tags."$tag" --registry="$reg" 2>/dev/null || true
 }
 
+# ab_any_ext_outdated <slot> — prints "1" when any configured extension in the
+# slot's profile closure is older than its npm latest, else "". Extensions are
+# installed from their own dist-tag into <slot>/profiles/node_modules (pnpm
+# closure); a release there can change behaviour without the dsh package
+# version moving, and prepare must not early-return past it (2026-08-21:
+# dsh-track 0.6.0 added the session graph the running 0.5.0 lacked).
+ab_any_ext_outdated() {
+  local slot="$1" _e extnpm installed latest
+  [ -n "$slot" ] || { printf ''; return; }
+  while IFS= read -r _e; do
+    [ -n "$_e" ] || continue
+    extnpm=$(printf '%s' "$_e" | jq -r '.npm // ""')
+    if [ -n "$extnpm" ]; then
+      installed=$(node -e "try{console.log(require('$(ab_slot_dir "$slot")/profiles/node_modules/$extnpm/package.json').version)}catch(e){}" 2>/dev/null)
+      latest=$(npm view "$extnpm" dist-tags.latest --registry="$(ab_npm_registry)" 2>/dev/null || true)
+      if [ -n "$installed" ] && [ -n "$latest" ] && [ "$installed" != "$latest" ]; then
+        # stderr: this function is captured via $() — stdout must stay clean
+        ab_err "  extension $extnpm: slot has $installed, npm latest $latest"
+        printf '1'
+        return 0
+      fi
+    fi
+  done < <(ab_config_items '.extensions // [] | .[]')
+  printf ''
+}
+
 # ab_npm_published_at <version> — ISO timestamp when a version was published.
 ab_npm_published_at() {
   local ver pkg reg


### PR DESCRIPTION
## 背景

`ab.sh prepare` 在主 dsh 包版本不变时提前 return，但扩展（dsh-track 等）从自己的 dist-tag 解析：**扩展发新版时主包版本不动**，候选槽会一直用旧扩展。

2026-08-21 事故：dsh-track 0.6.0 补上了会话图功能（0.5.0 缺失），但 prepare 因 rc.8 未变直接跳过，候选槽继续装 0.5.0。

## 修复

- 新增 `ab_any_ext_outdated`：对比 current 槽已装扩展版本 vs npm latest（日志走 stderr，保证 `$()` 捕获的 stdout 干净）
- prepare 提前 return 增加条件：扩展也都已是最新才跳过

## 验证

- `prepare --slot b` 检测到 dsh-track 0.5.0→0.6.0，正确重新准备
- staging `/api/track/calendar` 404 → 200，build-all 后 8 sessions 有数据
- 生产 switch + confirm 四门全过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated snapshot preparation to detect outdated extensions, even when the core package version has not changed.
  * Automatically re-prepares affected slots when newer extension versions are available.
  * Improved status and warning messages to clearly indicate extension updates and preparation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->