### PR TITLE
fix(dsh-session-recovery): rc.1 compat + duplicate-block repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Each entry links its squash-merged PR.
 
 ## [Unreleased]
 
+### dsh-session-recovery 兼容 rc.1 + 重复块损坏修复
+
+- `fix(dsh-session-recovery)`: `lib/dsh.mjs` 兼容当前 rc.1 快照 —— persistence
+  类改名（`SessionPersistenceJsonl` → `JsonlSessionPersistence`）、识别 slot
+  profile 布局（`$DSH_HOME/source/current/profiles/node_modules`），修复原脚本
+  `SessionPersistenceJsonl is not a constructor` 问题。
+- `fix(dsh-session-recovery)`: 新增 `repair-session-dedup.mjs` —— 处理「重复事件块
+  导致 seq 不连续 / torn record」的损坏形态（与单帧重压不同）：保留每个 seq 首次
+  出现、丢弃重复，再用 DSH 同款压缩器重新分帧并全量校验后替换；`--dry-run`、
+  失败自动还原。
+
 ### A/B 槽用户配置迁移（key / 模型配置跟随 current）
 
 - `fix(ab)`: 槽级 `.credentials.yaml`（API key）和 `settings.yaml`（模型选择/UI 偏好）

--- a/skills/dsh-session-recovery/scripts/lib/dsh.mjs
+++ b/skills/dsh-session-recovery/scripts/lib/dsh.mjs
@@ -1,11 +1,16 @@
 /**
  * Shared helpers: resolve the DSH session persistence backend and load it
- * exactly as the running `dsh web` server uses it, across both install modes:
+ * exactly as the running `dsh web` server uses it, across all install modes:
  *
  *  - source checkout (A/B snapshots): `$DSH_HOME/source/current` → packages/
- *  - npm install (lib production):  `$DSH_HOME/profiles/node_modules` closure
+ *  - profile install under source:    `$DSH_HOME/source/current` → profiles/node_modules
+ *  - npm install (lib production):    `$DSH_HOME/profiles/node_modules` closure
+ *
+ * The persistence class was renamed across snapshots (`SessionPersistenceJsonl`
+ * in older builds, `JsonlSessionPersistence` in rc.1). We accept both so the
+ * diagnostic scripts work against whatever snapshot is currently linked.
  */
-import { readlinkSync, readdirSync } from 'node:fs'
+import { readlinkSync, readdirSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { createRequire } from 'node:module'
@@ -29,29 +34,39 @@ export function resolveSourceRoot() {
 
 export const defaultSessionsRoot = () => join(DSH_HOME, 'sessions')
 
-/** 源码 checkout 是否存在（A/B 快照机制的特征）。 */
-function hasSourceCheckout() {
-  try {
-    const current = join(DSH_HOME, 'source', 'current')
-    readlinkSync(current)
-    return true
-  } catch {
-    return false
-  }
+/** Absolute path to the package dir for an npm-scope package, or null. */
+function packageDir(baseNodeModules, pkgName) {
+  return join(baseNodeModules, ...pkgName.split('/'))
 }
 
 /**
- * 双路径解析 persistence 后端。判别以「是否有源码 checkout」为准：
- * 源码模式（A/B 快照）→ 源码 packages/；npm 安装（lib 生产）→ profile 闭包。
+ * Resolve the require handle + mode for an `@deepseek-ai/*` package.
+ * Tries, in order: source packages/, source profile closure, npm profile closure.
  */
-function persistenceRequire() {
-  if (hasSourceCheckout()) {
-    const sourceRoot = resolveSourceRoot()
-    const pkgDir = join(sourceRoot, 'packages', 'session', 'session-persistence-jsonl')
-    return { require: createRequire(join(pkgDir, 'package.json')), mode: 'source' }
+function resolvePkgRequire(pkgName, sourceRelPath) {
+  const current = join(DSH_HOME, 'source', 'current')
+  if (existsSync(current)) {
+    // 1) genuine source checkout: <current>/packages/<...>
+    const srcPkg = join(current, 'packages', ...sourceRelPath)
+    if (existsSync(join(srcPkg, 'package.json'))) {
+      return { require: createRequire(join(srcPkg, 'package.json')), mode: 'source' }
+    }
+    // 2) profile install under source (slot-a/slot-b): <current>/profiles/node_modules
+    const profBase = join(current, 'profiles', 'node_modules')
+    const profPkg = packageDir(profBase, pkgName)
+    if (existsSync(join(profPkg, 'package.json'))) {
+      return { require: createRequire(join(profPkg, 'package.json')), mode: 'profile' }
+    }
   }
-  const pkgDir = join(DSH_HOME, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-session-persistence-jsonl')
-  return { require: createRequire(join(pkgDir, 'package.json')), mode: 'npm' }
+  // 3) npm install (lib production): <DSH_HOME>/profiles/node_modules
+  const npmBase = join(DSH_HOME, 'profiles', 'node_modules')
+  const npmPkg = packageDir(npmBase, pkgName)
+  return { require: createRequire(join(npmPkg, 'package.json')), mode: 'npm' }
+}
+
+/** Resolve the persistence backend require handle. */
+function persistenceRequire() {
+  return resolvePkgRequire('@deepseek-ai/dsh-session-persistence-jsonl', ['session', 'session-persistence-jsonl'])
 }
 
 /** Public handle to the persistence backend's require (for frame-level tools). */
@@ -59,22 +74,13 @@ export function persistenceRequireHandle() {
   return persistenceRequire()
 }
 
-/**
- * 双路径解析 `@deepseek-ai/dsh-session` 的 require（repair 脚本 decodeStorageRecord 用）。
- * 判别与 persistenceRequire 一致：源码 checkout → 源码 packages/；npm → profile 闭包。
- */
+/** Resolve the `@deepseek-ai/dsh-session` require handle (decodeStorageRecord). */
 export function sessionRequire() {
-  if (hasSourceCheckout()) {
-    const sourceRoot = resolveSourceRoot()
-    const pkgDir = join(sourceRoot, 'packages', 'session', 'session-persistence-jsonl')
-    return createRequire(join(pkgDir, 'package.json'))
-  }
-  const pkgDir = join(DSH_HOME, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-session')
-  return createRequire(join(pkgDir, 'package.json'))
+  return resolvePkgRequire('@deepseek-ai/dsh-session', ['session', 'dsh-session']).require
 }
 
 /**
- * Build a SessionPersistenceJsonl instance bound to the real session root.
+ * Build a persistence instance bound to the real session root.
  * Uses the COMPILED packages (lib/) so behaviour matches the running server.
  * Returns the resolved mode so callers can report which backend they used.
  */
@@ -89,10 +95,12 @@ export function loadPersistence(root = defaultSessionsRoot()) {
   } catch {
     ({ Context } = require('@deepseek-ai/cordis'))
   }
-  const { SessionPersistenceJsonl } = require('@deepseek-ai/dsh-session-persistence-jsonl')
+  const mod = require('@deepseek-ai/dsh-session-persistence-jsonl')
+  // Class renamed across snapshots: older builds used SessionPersistenceJsonl.
+  const Persistence = mod.JsonlSessionPersistence ?? mod.SessionPersistenceJsonl ?? mod.default
   const ctx = new Context()
   ctx.sessions = { list: () => [] } // no live sessions in a diagnostic context
-  const persistence = new SessionPersistenceJsonl(ctx, { root, compression: 'zstd' })
+  const persistence = new Persistence(ctx, { root, compression: 'zstd' })
   return { persistence, root, mode, sourceRoot: mode === 'source' ? resolveSourceRoot() : undefined }
 }
 

--- a/skills/dsh-session-recovery/scripts/repair-session-dedup.mjs
+++ b/skills/dsh-session-recovery/scripts/repair-session-dedup.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * repair-session-dedup.mjs — lossless repair of a session log corrupted by a
+ * DUPLICATED event block (same `seq` appearing twice), which makes the DSH
+ * reader throw "corrupt Zstandard session log: complete frame contains a torn
+ * JSONL record".
+ *
+ * Strategy: decode the whole stream to events, drop the SECOND (duplicate)
+ * occurrence of any seq that already appeared (keeping the first, which is what
+ * the reader commits), then re-frame the corrected rows with DSH's own
+ * compressor and validate with the real reader before swapping in place.
+ *
+ * Usage:
+ *   node repair-session-dedup.mjs --id <session-id> [--dry-run]
+ *   node repair-session-dedup.mjs --dir <path>     [--dry-run]
+ *   [--root <sessions-root>] [--backup-dir <dir>] [--lines-per-frame N]
+ *
+ * Exit codes: 0 repaired & verified; 2 nothing to repair (already valid);
+ * 1 any failure (original file is left untouched on failure).
+ */
+import { parseArgs } from 'node:util'
+import { zstdCompress, zstdDecompressSync, constants } from 'node:zlib'
+import { promisify } from 'node:util'
+import { readFile, writeFile, rename, mkdir, copyFile, rm, access } from 'node:fs/promises'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { loadPersistence, enumerateSessionLogs, sessionRequire } from './lib/dsh.mjs'
+
+const zstdCompressAsync = promisify(zstdCompress)
+const CHECKSUM_OPTIONS = { params: { [constants.ZSTD_c_checksumFlag]: 1 } }
+const ZSTD_MAGIC = 4247762216
+
+const { values } = parseArgs({
+  options: {
+    id: { type: 'string' },
+    dir: { type: 'string' },
+    root: { type: 'string' },
+    'backup-dir': { type: 'string' },
+    'lines-per-frame': { type: 'string' },
+    'dry-run': { type: 'boolean', default: false },
+  },
+})
+const linesPerFrame = Number(values['lines-per-frame'] ?? 200)
+
+function fail(msg) {
+  console.error(`ABORT: ${msg}`)
+  process.exit(1)
+}
+
+// --- locate the log file ---------------------------------------------------
+const { persistence, root } = loadPersistence(values.root)
+const { decodeStorageRecord } = sessionRequire()('@deepseek-ai/dsh-session')
+
+let target
+if (values.dir) {
+  const p = values.dir
+  const isLog = p.endsWith('session.jsonl.zstd') || p.endsWith('session.jsonl')
+  target = isLog ? p : join(p, 'session.jsonl.zstd')
+  try { await access(target) } catch { fail(`cannot access log: ${target}`) }
+} else if (values.id) {
+  const logs = await enumerateSessionLogs(values.root)
+  const matches = logs.filter(l => l.id === values.id)
+  if (matches.length === 0) fail(`no session log found for id ${values.id} under ${root}`)
+  if (matches.length > 1) fail(`session id ${values.id} appears in multiple project dirs: ${matches.map(m => m.project).join(', ')}`)
+  target = matches[0].log
+  if (matches[0].compression !== 'zstd') fail(`session ${values.id} is a plaintext log — frame repair not applicable`)
+} else {
+  fail('provide --id <session-id> or --dir <path>')
+}
+
+const EXPECTED_ID = values.id ?? target.split('/').pop()
+const SESSION_DIR = target.replace(/\/session\.jsonl\.zstd$/, '')
+const LOG = target
+const BACKUP_DIR = values['backup-dir'] ?? join(process.cwd(), 'backups', SESSION_DIR.split('/').pop())
+
+// --- 0. pre-check: nothing to repair when the file already validates ---------
+try {
+  const first = await persistence.readFirstZstdLine(LOG)
+  if (first.startsWith('{"type":"session"')) {
+    await persistence.readPrefix(LOG, EXPECTED_ID)
+    console.log(`ALREADY VALID: ${EXPECTED_ID} passes header + full-read checks — nothing to repair`)
+    process.exit(2)
+  }
+} catch {
+  // falls through to repair
+}
+
+// --- 1. scan frames + decode the whole stream ------------------------------
+function scanZstdFrames(buffer) {
+  const frames = []; let offset = 0
+  while (offset < buffer.length) {
+    const start = offset
+    if (buffer.length - offset < 4) break
+    if (buffer.readUInt32LE(offset) !== ZSTD_MAGIC) throw new Error(`corrupt Zstandard session log: invalid frame magic at byte ${offset}`)
+    offset += 4
+    if (offset === buffer.length) break
+    const descriptor = buffer.readUInt8(offset); offset += 1
+    if ((descriptor & 24) !== 0) throw new Error(`corrupt Zstandard session log: reserved frame-header bit at byte ${offset - 1}`)
+    const contentSizeFlag = descriptor >>> 6
+    const singleSegment = (descriptor & 32) !== 0
+    const checksum = (descriptor & 4) !== 0
+    const dictionaryFlag = descriptor & 3
+    const dictionaryBytes = dictionaryFlag === 3 ? 4 : dictionaryFlag
+    const contentSizeBytes = contentSizeFlag === 0 ? singleSegment ? 1 : 0 : 1 << contentSizeFlag
+    const remainingHeaderBytes = (singleSegment ? 0 : 1) + dictionaryBytes + contentSizeBytes
+    if (buffer.length - offset < remainingHeaderBytes) break
+    offset += remainingHeaderBytes
+    for (;;) {
+      if (buffer.length - offset < 3) break
+      const blockHeader = buffer.readUIntLE(offset, 3); offset += 3
+      const lastBlock = (blockHeader & 1) !== 0
+      const blockType = blockHeader >>> 1 & 3
+      const blockSize = blockHeader >>> 3
+      if (blockType === 3) throw new Error(`corrupt Zstandard session log: reserved block type at byte ${offset - 3}`)
+      const payloadBytes = blockType === 1 ? 1 : blockSize
+      if (buffer.length - offset < payloadBytes) break
+      offset += payloadBytes
+      if (lastBlock) break
+    }
+    if (checksum) { if (buffer.length - offset < 4) break; offset += 4 }
+    frames.push({ start, end: offset })
+  }
+  return frames
+}
+
+const raw = await readFile(LOG)
+const frames = scanZstdFrames(raw)
+let plain = Buffer.alloc(0)
+for (const f of frames) plain = Buffer.concat([plain, zstdDecompressSync(raw.subarray(f.start, f.end))])
+const text = plain.toString('utf8')
+if (!text.endsWith('\n')) fail('plaintext does not end with a newline (torn tail) — refusing automatic repair')
+const lines = text.split('\n'); lines.pop()
+console.log(`frames: ${frames.length}; decompressed ${plain.length} bytes -> ${lines.length} rows`)
+
+const header = JSON.parse(lines[0])
+if (header.type !== 'session' || header.id !== EXPECTED_ID) {
+  fail(`header id mismatch: file header says ${header.id}, expected ${EXPECTED_ID}`)
+}
+console.log(`header OK: id=${header.id} cwd=${header.cwd ?? '(none)'} createdAt=${new Date(header.createdAt).toISOString()}`)
+
+// --- 2. decode rows, keep first occurrence of each seq ----------------------
+const seen = new Set()
+let dupRemoved = 0
+let totalEvents = 0
+let lastSeq = -1
+const newRows = [lines[0]]   // header row, byte-identical
+for (let r = 1; r < lines.length; r++) {
+  let events
+  try { events = decodeStorageRecord(JSON.parse(lines[r])) } catch { fail(`row ${r + 1} failed to decode: ${lines[r].slice(0, 120)}`) }
+  // Partition this row's events into duplicates (already seen) vs new.
+  const keep = []
+  let allDup = true
+  for (const ev of events) {
+    if (seen.has(ev.seq)) { dupRemoved++; continue }
+    seen.add(ev.seq); keep.push(ev); allDup = false
+  }
+  if (allDup) continue                       // whole row was a duplicate — drop it
+  if (keep.length === events.length) {
+    newRows.push(lines[r])                    // untouched row — keep byte-identical
+  } else {
+    // Straddling row (part dup, part new): emit the new events as individual rows.
+    for (const ev of keep) newRows.push(JSON.stringify(ev))
+    console.log(`  split straddling row ${r + 1}: kept ${keep.length} of ${events.length} events`)
+  }
+  for (const ev of keep) totalEvents++
+}
+
+// --- 3. assert the deduped stream is contiguous ----------------------------
+for (let i = 0; i < newRows.length - 1; i++) {
+  const evs = decodeStorageRecord(JSON.parse(newRows[i + 1]))
+  for (const ev of evs) {
+    if (ev.seq !== lastSeq + 1) fail(`after dedup, non-contiguous seq: expected ${lastSeq + 1}, got ${ev.seq}`)
+    lastSeq = ev.seq
+  }
+}
+if (lastSeq + 1 !== totalEvents) fail(`event count mismatch: contiguous run has seq up to ${lastSeq} (${lastSeq + 1} events) but total ${totalEvents}`)
+console.log(`dedup removed ${dupRemoved} duplicate events; contiguous stream: ${totalEvents} events (seq 0..${lastSeq})`)
+
+if (dupRemoved === 0) {
+  console.log('no duplicates found — nothing to repair (content already contiguous)')
+  process.exit(2)
+}
+
+// --- 4. re-frame with DSH framing ------------------------------------------
+const rebuiltFrames = []
+rebuiltFrames.push(await zstdCompressAsync(Buffer.from(newRows[0] + '\n'), CHECKSUM_OPTIONS))
+const body = newRows.slice(1)
+for (let i = 0; i < body.length; i += linesPerFrame) {
+  const chunk = body.slice(i, i + linesPerFrame).join('\n') + '\n'
+  rebuiltFrames.push(await zstdCompressAsync(Buffer.from(chunk, 'utf8'), CHECKSUM_OPTIONS))
+}
+const rebuilt = Buffer.concat(rebuiltFrames)
+console.log(`rebuilt: ${rebuiltFrames.length} frames, ${rebuilt.length} bytes (original ${raw.length})`)
+
+// --- 5. validate rebuilt bytes ---------------------------------------------
+const tmpPath = `${LOG}.repair-tmp`
+await writeFile(tmpPath, rebuilt, { mode: 0o600 })
+
+// 5a. header frame check (works on any path; no identity requirement).
+try {
+  const firstLine = await persistence.readFirstZstdLine(tmpPath)
+  if (!firstLine.startsWith('{"type":"session"')) fail(`rebuilt header frame is not a session header`)
+} catch (error) {
+  await rm(tmpPath, { force: true })
+  fail(`readFirstZstdLine() failed on rebuilt file: ${error.message}`)
+}
+console.log('header frame OK')
+
+// 5b. self-check: decode the rebuilt file and assert contiguity/event count.
+//     readPrefix() has an identity check that only passes on the canonical
+//     path, so for the pre-swap check we decode the frames ourselves.
+function decodeFileEvents(path) {
+  const buf = readFileSync(path)
+  const fs = scanZstdFrames(buf)
+  let p = Buffer.alloc(0)
+  for (const f of fs) p = Buffer.concat([p, zstdDecompressSync(buf.subarray(f.start, f.end))])
+  const ls = p.toString('utf8').split('\n'); ls.pop()
+  const evs = []
+  for (let r = 1; r < ls.length; r++) evs.push(...decodeStorageRecord(JSON.parse(ls[r])))
+  return evs
+}
+const decodedEvents = decodeFileEvents(tmpPath)
+if (decodedEvents.length !== totalEvents) {
+  await rm(tmpPath, { force: true })
+  fail(`rebuilt decodes to ${decodedEvents.length} events, expected ${totalEvents}`)
+}
+for (let i = 0; i < decodedEvents.length; i++) {
+  if (decodedEvents[i].seq !== i) {
+    await rm(tmpPath, { force: true })
+    fail(`rebuilt event ${i} has seq ${decodedEvents[i].seq} (non-contiguous)`)
+  }
+}
+console.log(`rebuilt decodes cleanly: ${decodedEvents.length} contiguous events`)
+
+if (values['dry-run']) {
+  await rm(tmpPath, { force: true })
+  console.log('DRY-RUN: rebuilt file validated; original untouched. To apply, re-run without --dry-run.')
+  process.exit(0)
+}
+
+// --- 6. backup + reversible swap -------------------------------------------
+await mkdir(BACKUP_DIR, { recursive: true })
+const backupPath = join(BACKUP_DIR, 'session.jsonl.zstd.orig-corrupt')
+await copyFile(LOG, backupPath)
+console.log(`backup written: ${backupPath}`)
+
+const inPlaceOrig = `${LOG}.orig-in-place`
+await rename(LOG, inPlaceOrig)
+await rename(tmpPath, LOG)
+const restore = async () => {
+  await rename(LOG, tmpPath).catch(() => {})
+  await rename(inPlaceOrig, LOG).catch(() => {})
+}
+
+// 6c. authoritative validation with the DSH reader on the canonical path.
+let prefix
+try {
+  prefix = await persistence.readPrefix(LOG, EXPECTED_ID)
+} catch (error) {
+  await restore()
+  fail(`persistence.readPrefix() failed on repaired file (original restored): ${error.message}`)
+}
+if (prefix.events.length !== totalEvents) {
+  await restore()
+  fail(`reader event count ${prefix.events.length} != expected ${totalEvents} (original restored)`)
+}
+console.log(`reader accepted repaired file on canonical path: ${prefix.events.length} events`)
+
+await rm(inPlaceOrig, { force: true })
+console.log(`original corrupt file removed (backup kept at ${backupPath})`)
+console.log('REPAIR COMPLETE')


### PR DESCRIPTION
## 背景

dsh-session-recovery 的诊断脚本在 rc.1 快照下失效（`SessionPersistenceJsonl is not a constructor`）：persistence 类改名 + slot profile 布局未识别。

## 改动

1. **`lib/dsh.mjs`** — 兼容 rc.1：
   - persistence 类名 `SessionPersistenceJsonl` → `JsonlSessionPersistence`（新旧都接受）
   - 识别 slot profile 布局（`$DSH_HOME/source/current/profiles/node_modules`）
2. **`repair-session-dedup.mjs`**（新增）— 处理「重复事件块导致 seq 不连续 / torn record」：
   - 保留每个 seq 首次出现、丢弃重复
   - DSH 同款压缩器重新分帧 + 真实读取器全量校验后替换
   - `--dry-run`、失败自动还原

## 验证

session-a228136b：移除 10 个重复事件 → 206325 事件连续（seq 0..206324），读取器在规范路径接受，会话校验 162/0 pass。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repair tool for session logs affected by duplicate events.
  * Supports dry runs, backups, reversible replacement, configurable frame sizes, and validation.
  * Automatically restores the original log if repair validation fails.

* **Bug Fixes**
  * Improved compatibility with rc.1 installations and persistence layouts.
  * Enhanced session and persistence loading across supported installation profiles and snapshot formats.

* **Documentation**
  * Added unreleased changelog entries describing the compatibility fixes and repair utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->