### PR TITLE
fix(ab): isolate staging dsh web instance from shared ~/.dsh state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules/
 .DS_Store
 *.log
 
+# session-recovery repair backups (large session logs)
+backups/
+
 # plugin build artifacts
 plugins/*/lib/
 plugins/*/node_modules/

--- a/README.en.md
+++ b/README.en.md
@@ -461,9 +461,14 @@ $AB stage --slot a --port 3082 --keep --yes   # background (nohup); stop with th
 - **Requires explicit `--yes`** confirmation before starting; without `--yes` it refuses and exits;
 - Target port taken → errors out, telling you to change `--port`;
 - `--keep` runs in background and prints the log path and stop command
-  (`kill $(lsof -tiTCP:<port> -sTCP:LISTEN)`).
+  (`kill $(lsof -tiTCP:<port> -sTCP:LISTEN)`);
+- **Session/storage isolation**: the temp instance boots with `--patch <throwaway cordis.patch.yml>`
+  redirecting `session-persistence-jsonl.root` and `storage-json.root` to a throwaway temp dir, so it
+  can never write the production `~/.dsh` sessions/storages (2026-08-21 incident: a prepare-stage
+  second instance rewrote an active session's tail → seq rewind the reader rejects).
 
-⚠️ During a temporary instance: **read-only**, don't run writes concurrently, close it when done.
+⚠️ During a temporary instance: **isolated read-only**, don't run writes concurrently, close it when done;
+even a stray write can't touch production sessions/storages.
 
 ### Scenario F · New version has problems → rollback (available anytime)
 

--- a/README.md
+++ b/README.md
@@ -420,9 +420,12 @@ $AB stage --slot a --port 3082 --keep --yes   # 后台跑（nohup），停止用
 - **先检测**：已有 web 实例在跑（如生产 3080）→ 打印警告"第二个实例共享 ~/.dsh，只读查看"；
 - **要求你 `--yes` 明确确认**才启动；不带 `--yes` 直接拒绝并退出；
 - 目标端口被占 → 直接报错让你换 `--port`；
-- `--keep` 后台跑并打印日志路径与停止命令（`kill $(lsof -tiTCP:<port> -sTCP:LISTEN)`）。
+- `--keep` 后台跑并打印日志路径与停止命令（`kill $(lsof -tiTCP:<port> -sTCP:LISTEN)`）；
+- **会话/存储隔离**：临时实例通过 `--patch <临时cordis.patch.yml>` 把 `session-persistence-jsonl.root`
+  与 `storage-json.root` 重定向到一个一次性 temp 目录，**永远写不进生产 `~/.dsh`** 的 sessions/storages
+  （2026-08-21 事故：prepare 冒烟起的第二个实例重写了一个活跃会话尾部，导致 seq 回跳、读取器拒读）。
 
-⚠️ 临时实例期间：**只读**，别同时做写操作，看完就关。
+⚠️ 临时实例期间：**隔离只读**，别同时做写操作，看完就关；即使误触也不会碰生产会话/存储。
 
 ### 场景 F · 新版有问题 → 回滚（随时可回）
 

--- a/skills/dsh-session-recovery/scripts/repair-session-dedup.mjs
+++ b/skills/dsh-session-recovery/scripts/repair-session-dedup.mjs
@@ -5,13 +5,17 @@
  * reader throw "corrupt Zstandard session log: complete frame contains a torn
  * JSONL record".
  *
- * Strategy: decode the whole stream to events, drop the SECOND (duplicate)
- * occurrence of any seq that already appeared (keeping the first, which is what
- * the reader commits), then re-frame the corrected rows with DSH's own
- * compressor and validate with the real reader before swapping in place.
+ * Strategy: decode the whole stream to events and collapse the duplicate seq
+ * range. A duplicate seq appears when the same range is written twice — either
+ * as a genuine duplicate write (identical events) or, more often, as a
+ * crash-recovery REWIND where the harness re-wrote the tail with DIFFERENT
+ * events at the same seqs. For a rewind the LATER write is the live version, so
+ * the default keeps the LAST occurrence of each seq (`--keep last`); `--keep
+ * first` keeps the earliest instead. Then re-frame the corrected rows with DSH's
+ * own compressor and validate with the real reader before swapping in place.
  *
  * Usage:
- *   node repair-session-dedup.mjs --id <session-id> [--dry-run]
+ *   node repair-session-dedup.mjs --id <session-id> [--dry-run] [--keep last|first]
  *   node repair-session-dedup.mjs --dir <path>     [--dry-run]
  *   [--root <sessions-root>] [--backup-dir <dir>] [--lines-per-frame N]
  *
@@ -37,10 +41,12 @@ const { values } = parseArgs({
     root: { type: 'string' },
     'backup-dir': { type: 'string' },
     'lines-per-frame': { type: 'string' },
+    'keep': { type: 'string', default: 'last' },
     'dry-run': { type: 'boolean', default: false },
   },
 })
 const linesPerFrame = Number(values['lines-per-frame'] ?? 200)
+const keep = values.keep === 'first' ? 'first' : 'last'
 
 function fail(msg) {
   console.error(`ABORT: ${msg}`)
@@ -138,8 +144,22 @@ if (header.type !== 'session' || header.id !== EXPECTED_ID) {
 }
 console.log(`header OK: id=${header.id} cwd=${header.cwd ?? '(none)'} createdAt=${new Date(header.createdAt).toISOString()}`)
 
-// --- 2. decode rows, keep first occurrence of each seq ----------------------
-const seen = new Set()
+// --- 2. decode rows, pick one occurrence of each seq -----------------------
+// A seq appearing more than once is a duplicate write. For a crash-recovery
+// REWIND the LATER copy is live, so `keep=last` (default) wins; `keep=first`
+// wins for a genuine identical duplicate. We build a seq -> (row,eventIndex)
+// map of the chosen occurrence, then keep a row byte-identical iff every event
+// it carries is the chosen occurrence (dropping fully-shadowed rows).
+const chosen = new Map()   // seq -> {r, ei}
+for (let r = 1; r < lines.length; r++) {
+  let events
+  try { events = decodeStorageRecord(JSON.parse(lines[r])) } catch { fail(`row ${r + 1} failed to decode: ${lines[r].slice(0, 120)}`) }
+  for (let ei = 0; ei < events.length; ei++) {
+    const seq = events[ei].seq
+    if (keep === 'first') { if (!chosen.has(seq)) chosen.set(seq, { r, ei }) }
+    else chosen.set(seq, { r, ei })
+  }
+}
 let dupRemoved = 0
 let totalEvents = 0
 let lastSeq = -1
@@ -147,22 +167,19 @@ const newRows = [lines[0]]   // header row, byte-identical
 for (let r = 1; r < lines.length; r++) {
   let events
   try { events = decodeStorageRecord(JSON.parse(lines[r])) } catch { fail(`row ${r + 1} failed to decode: ${lines[r].slice(0, 120)}`) }
-  // Partition this row's events into duplicates (already seen) vs new.
-  const keep = []
-  let allDup = true
-  for (const ev of events) {
-    if (seen.has(ev.seq)) { dupRemoved++; continue }
-    seen.add(ev.seq); keep.push(ev); allDup = false
+  const keepIdx = []
+  for (let ei = 0; ei < events.length; ei++) {
+    const c = chosen.get(events[ei].seq)
+    if (c && c.r === r && c.ei === ei) keepIdx.push(ei)
+    else dupRemoved++
   }
-  if (allDup) continue                       // whole row was a duplicate — drop it
-  if (keep.length === events.length) {
-    newRows.push(lines[r])                    // untouched row — keep byte-identical
-  } else {
-    // Straddling row (part dup, part new): emit the new events as individual rows.
-    for (const ev of keep) newRows.push(JSON.stringify(ev))
-    console.log(`  split straddling row ${r + 1}: kept ${keep.length} of ${events.length} events`)
+  if (keepIdx.length === 0) continue                     // fully shadowed row — drop it
+  if (keepIdx.length === events.length) newRows.push(lines[r])   // keep byte-identical
+  else {                                                  // straddling row — emit chosen events
+    for (const ei of keepIdx) newRows.push(JSON.stringify(events[ei]))
+    console.log(`  split straddling row ${r + 1}: kept ${keepIdx.length} of ${events.length} events`)
   }
-  for (const ev of keep) totalEvents++
+  for (const ei of keepIdx) totalEvents++
 }
 
 // --- 3. assert the deduped stream is contiguous ----------------------------
@@ -174,7 +191,7 @@ for (let i = 0; i < newRows.length - 1; i++) {
   }
 }
 if (lastSeq + 1 !== totalEvents) fail(`event count mismatch: contiguous run has seq up to ${lastSeq} (${lastSeq + 1} events) but total ${totalEvents}`)
-console.log(`dedup removed ${dupRemoved} duplicate events; contiguous stream: ${totalEvents} events (seq 0..${lastSeq})`)
+console.log(`dedup (keep=${keep}) removed ${dupRemoved} shadowed events; contiguous stream: ${totalEvents} events (seq 0..${lastSeq})`)
 
 if (dupRemoved === 0) {
   console.log('no duplicates found — nothing to repair (content already contiguous)')

--- a/skills/dsh-snapshot-ab/scripts/ab.sh
+++ b/skills/dsh-snapshot-ab/scripts/ab.sh
@@ -871,8 +871,10 @@ ab_restart_web() {
 cmd_stage() {
   # Boot one slot's web on a STAGING port while production keeps running —
   # a second instance sharing ~/.dsh, safe only for read-only inspection.
-  # Coexistence is detected and requires explicit approval (--yes).
-  local slot port
+  # We isolate its session/storage writes to a throwaway dir so it can never
+  # touch the production state (2026-08-21 incident). Coexistence is detected
+  # and requires explicit approval (--yes).
+  local slot port iso
   slot="$FLAG_SLOT"
   [ -n "$slot" ] || ab_die "usage: ab.sh stage --slot a|b [--port N] [--keep]"
   local dir; dir=$(ab_slot_dir "$slot")
@@ -887,15 +889,17 @@ cmd_stage() {
       ab_die "a dsh web instance is already running — a second instance shares ~/.dsh (sessions/storages) and must be READ-ONLY inspection only. Pass --yes to confirm you understand, then it will boot."
     fi
   fi
-  ab_log "booting slot $slot (${dir}) web on http://127.0.0.1:$port — production instance keeps running; this one is READ-ONLY inspection."
+  iso="$(ab_stage_isolation_patch)" || ab_die "failed to create staging isolation patch"
+  ab_log "booting slot $slot (${dir}) web on http://127.0.0.1:$port — production instance keeps running; this one is READ-ONLY inspection (session/storage isolated to $iso)."
   if [ "$FLAG_KEEP" = "1" ]; then
     # shellcheck disable=SC2086
-    ( cd "$dir" && nohup $(ab_boot_cmd "$dir") web --port "$port" >"$AB_SOURCE/web-stage-$slot.log" 2>&1 & echo $! > "$AB_SOURCE/stage-$slot.pid" )
-    ab_ok "staging server up (log $AB_SOURCE/web-stage-$slot.log, pid $(cat "$AB_SOURCE/stage-$slot.pid"))"
+    ( cd "$dir" && nohup $(ab_boot_cmd "$dir") --profile web --patch "$iso/cordis.patch.yml" --no-open --port "$port" >"$AB_SOURCE/web-stage-$slot.log" 2>&1 & echo $! > "$AB_SOURCE/stage-$slot.pid" )
+    printf '%s\n' "$iso" > "$AB_SOURCE/stage-$slot.iso"
+    ab_ok "staging server up (log $AB_SOURCE/web-stage-$slot.log, pid $(cat "$AB_SOURCE/stage-$slot.pid"), isolation dir $iso)"
     ab_log "  stop it: kill \$(lsof -tiTCP:$port -sTCP:LISTEN)   # listener pid may differ from the wrapper"
   else
     # shellcheck disable=SC2086
-    ( cd "$dir" && exec $(ab_boot_cmd "$dir") web --port "$port" )
+    ( cd "$dir" && exec $(ab_boot_cmd "$dir") --profile web --patch "$iso/cordis.patch.yml" --no-open --port "$port" )
   fi
 }
 

--- a/skills/dsh-snapshot-ab/scripts/lib/acceptance.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/acceptance.sh
@@ -120,7 +120,7 @@ acc_build() {
 #   Returns 0 if the server answered every smoke path.
 acc_web_smoke() {
   local dir="$1" port="$2" host="$3" timeout="$4" keep="${5:-0}" approval="${6:-0}"
-  local log pid i code p allok=1 ws_arg
+  local log pid i code p allok=1 ws_arg iso
   # port must be free before booting a staging instance
   if lsof -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
     ab_err "port $port already in use — pick a free staging port (config web.port)"
@@ -134,6 +134,12 @@ acc_web_smoke() {
     fi
   fi
   log="$(mktemp -t dsh-ab-smoke.XXXXXX).log"
+  # isolate the second instance's session/storage writes to a throwaway dir so
+  # it can never touch the shared ~/.dsh production state (2026-08-21 incident).
+  if ! iso="$(ab_stage_isolation_patch)"; then
+    ab_err "failed to create staging isolation patch"
+    return 1
+  fi
   # --workspace-root exists on some snapshots and was removed on others; ask the
   # candidate's own CLI before passing it (acceptance must not assume flags).
   ws_arg=""
@@ -143,7 +149,7 @@ acc_web_smoke() {
   else
     ab_warn "  candidate's dsh web has no --workspace-root flag; smoke without it"
   fi
-  ab_log "smoke: $(ab_boot_cmd "$dir") web --port $port (log $log)"
+  ab_log "smoke: $(ab_boot_cmd "$dir") --profile web --patch $iso/cordis.patch.yml --port $port (log $log)"
   # npm-distribution slots are isolated DSH_HOMEs: their profiles live under
   # <slot>/profiles, so the booted web must see DSH_HOME=<slot-dir> or it would
   # load the USER-level ~/.dsh profile (and any source-linked extensions in it).
@@ -154,7 +160,7 @@ acc_web_smoke() {
     ab_log "  npm slot: DSH_HOME=$dir"
   fi
   # shellcheck disable=SC2086
-  ( cd "$dir" && nohup env $env_prefix $(ab_boot_cmd "$dir") web --port "$port" --host "$host" $ws_arg >"$log" 2>&1 & echo $! > "$log.pid" )
+  ( cd "$dir" && nohup env $env_prefix $(ab_boot_cmd "$dir") --profile web --patch "$iso/cordis.patch.yml" --no-open --host "$host" --port "$port" $ws_arg >"$log" 2>&1 & echo $! > "$log.pid" )
   pid=$(cat "$log.pid")
   i=0
   while [ "$i" -lt "$timeout" ]; do
@@ -194,7 +200,7 @@ acc_web_smoke() {
     done
   fi
   if [ "$keep" = "1" ]; then
-    ab_log "keeping staging server on http://$host:$port (pid $pid, log $log) for manual review"
+    ab_log "keeping staging server on http://$host:$port (pid $pid, log $log, isolation dir $iso) for manual review"
   else
     # TERM first, then force-free the port (node may drain slowly on SIGTERM)
     kill "$pid" 2>/dev/null || true
@@ -207,6 +213,7 @@ acc_web_smoke() {
       lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | xargs kill -9 2>/dev/null || true
       sleep 1
     fi
+    rm -rf "$iso" 2>/dev/null || true
   fi
   [ "$allok" = "1" ]
 }

--- a/skills/dsh-snapshot-ab/scripts/lib/common.sh
+++ b/skills/dsh-snapshot-ab/scripts/lib/common.sh
@@ -461,3 +461,28 @@ ab_warn_coexistence() {
   done < <(ab_detect_web)
   [ "$found" = "1" ]
 }
+
+# ab_stage_isolation_patch — create a throwaway cordis.patch.yml that redirects a
+# staging dsh web's session/storage roots away from the shared ~/.dsh state.
+# A second instance (smoke / stage) sharing ~/.dsh is documented as READ-ONLY
+# inspection only; without isolation it can WRITE the production sessions/storages
+# (2026-08-21 incident: a prepare-stage instance re-wrote an active session's tail,
+# producing a seq rewind that the reader rejects). Booting with
+#   bin/dsh --profile web --patch "$(ab_stage_isolation_patch)/cordis.patch.yml"
+# makes the staging instance write to a throwaway dir instead. Echoes the dir
+# path; the caller should `rm -rf` it on teardown (keep it while a kept server
+# runs).
+ab_stage_isolation_patch() {
+  local iso
+  iso="$(mktemp -d -t dsh-ab-iso.XXXXXX)" || return 1
+  mkdir -p "$iso/sessions" "$iso/storages" || return 1
+  cat > "$iso/cordis.patch.yml" <<EOF
+- id: session-persistence-jsonl
+  config:
+    root: $iso/sessions
+- id: storage-json
+  config:
+    root: $iso/storages
+EOF
+  printf '%s\n' "$iso"
+}


### PR DESCRIPTION
## 背景 / Problem

`ab.sh stage` / `prepare` 的冒烟会在 staging 端口起**第二个 dsh web 实例**，与生产共享同一份 `~/.dsh` 的 sessions/storages。工具本身就把这种共存标为 **READ-ONLY inspection only**，但实例实际上**可写**。

2026-08-21 事故：一次 `ab.sh prepare` 起的第二个实例把**正在运行的会话尾部**用相同 seq、不同内容重写了一遍（`seq 201773..201782` 双写），导致读取器 `readPrefix` 报 `corrupt Zstandard session log: complete frame contains a torn JSONL record`，历史打不开。

## 根因

- `session-persistence-jsonl.root` / `storage-json.root` 被 `ab_ensure_shared_userdata_patch` 强制指向 `~/.dsh/sessions` / `~/.dsh/storages`；
- 第二个实例（本应只读）加载了与生产相同的 workspace/session 并续写，两个 writer 从同一 base seq 各写一份 → seq 回跳；
- 写入端 `appendLines` 不校验 seq 唯一性，读取端严格校验 → 双写被落盘后无法读取。

## 修复 / Fix

把 staging 实例的会话/存储根目录重定向到一个**一次性 temp 目录**，使其**永远写不进生产 `~/.dsh`**：

- 新增 `ab_stage_isolation_patch()`（`lib/common.sh`）：生成临时 `cordis.patch.yml`，把两个 root 指到 `$(mktemp -d)/sessions|storages`；
- `acc_web_smoke()`（`lib/acceptance.sh`）与 `cmd_stage()`（`ab.sh`）：staging 启动改用 `bin/dsh --profile web --patch <temp> --no-open --port <p>`；
- 非 `--keep` 时 teardown 清理 temp 目录；`--keep` 时把 temp 路径写到 `stage-$slot.iso` 便于清理；
- `.gitignore` 增加 `backups/`（session-recovery 修复备份）。

顺带：`repair-session-dedup.mjs` 新增 `--keep last|first`（默认 last）——rewind 双写时**后写的是 live 版**，保留后写副本。

## 验证 / Verification

- `bash -n` 三个脚本语法通过；
- `ab_stage_isolation_patch()` 实测生成正确 patch；
- 用 `bin/dsh --profile web --patch <temp> --no-open --host 127.0.0.1 --port <p>` 实测启动：HTTP 200、temp sessions 为空、**生产会话文件 mtime/size 零改动**；
- 生产 `a228136b` 会话已用 `repair-session-dedup --keep last` 无损修复（206325 事件，162/162 全量通过）。